### PR TITLE
support all non-browser command line agents

### DIFF
--- a/rain_api_core/urs_util.py
+++ b/rain_api_core/urs_util.py
@@ -76,15 +76,13 @@ def get_urs_url(ctxt, to=False):
         urs_url += "&state={0}".format(to)
 
     # Try to handle scripts
-    agent_pattern = re.compile('^(curl|wget|aria2|python)', re.IGNORECASE)
-
     try:
         download_agent = ctxt['identity']['userAgent']
     except IndexError:
         log.debug("No User Agent!")
         return urs_url
 
-    if agent_pattern.match(download_agent):
+    if not download_agent.startswith('Mozilla'):
         urs_url += "&app_type=401"
 
     return urs_url


### PR DESCRIPTION
For consideration, this expands support to all command-line tools, not just curl/wget/aria2/python.

We've been using this model for datapool and ddn distribution for a while:
https://github.com/asfadmin/datapool/blob/test/src/datapool/auth.py#L24
https://github.com/asfadmin/sidedoor/blob/26278b6ec9f98c9db822d0d0b81c02d7a7722c68/app/etc/nginx/auth.conf#L18