### PR TITLE
[TEA Issue#342] Sort bucket map keys so prefixed buckets are evaluated first

### DIFF
--- a/rain_api_core/egress_util.py
+++ b/rain_api_core/egress_util.py
@@ -162,7 +162,10 @@ def check_private_bucket(bucket, b_map, object_name=""):
 
     # Check public bucket file:
     if 'PRIVATE_BUCKETS' in b_map:
-        for priv_bucket in b_map['PRIVATE_BUCKETS']:
+        # Prioritize prefixed buckets first, the deeper the better!
+        sorted_buckets = sorted(list(b_map['PRIVATE_BUCKETS'].keys()), key=lambda e: e.count("/"), reverse=True ) 
+        log.debug(f"Sorted PRIVATE buckets are {sorted_buckets}")
+        for priv_bucket in sorted_buckets:
             if bucket_prefix_match(bucket, prepend_bucketname(priv_bucket), object_name):
                 # This bucket is PRIVATE, return group!
                 return b_map['PRIVATE_BUCKETS'][priv_bucket]
@@ -174,8 +177,10 @@ def check_public_bucket(bucket, b_map, object_name=""):
 
     # Check for PUBLIC_BUCKETS in bucket map file
     if 'PUBLIC_BUCKETS' in b_map:
-        log.debug('we have a PUBLIC_BUCKETS in the ordinary bucketmap file')
-        for pub_bucket in b_map['PUBLIC_BUCKETS']:
+        # Prioritize prefixed buckets first, the deeper the better!
+        sorted_buckets = sorted(list(b_map['PUBLIC_BUCKETS'].keys()), key=lambda e: e.count("/"), reverse=True ) 
+        log.debug(f"Sorted PUBLIC buckets are {sorted_buckets}")
+        for pub_bucket in sorted_buckets:
             if bucket_prefix_match(bucket, prepend_bucketname(pub_bucket), object_name):
                 # This bucket is public!
                 log.debug("found a public, we'll take it")


### PR DESCRIPTION
https://github.com/asfadmin/thin-egress-app/issues/342

This change will ensure that the deepest depths of object-prefixed Private/public bucket maps are evaluated first. 

```
>>> b_map = {'PRIVATE_BUCKETS': {'s3-priv-1234abcd': ['testing_group_access'], 'aaa': ['bbb'], 's3-priv-5678efgh': ['testing_group_no_access'], "more/again": ['testing_group_access'], "bla/more": ["x"], "z/z/z": ["zip"]}}
>>> sorted(list(b_map['PRIVATE_BUCKETS'].keys()), key=lambda e: e.count("/"), reverse=True ) 
['z/z/z', 'more/again', 'bla/more', 's3-priv-1234abcd', 'aaa', 's3-priv-5678efgh']
>>> 
```

However, we really only currently support **ONE** level of prefix.  Before we can support deeper depths, we need to figure out a better way to assess nested public/private prefixes...

Right now, `s3://some-bucket/private/public/private/object.ext` would evaluated to public and private. 

That fix should happen in https://github.com/asfadmin/thin-egress-app/issues/343