### PR TITLE
PR-3042 Update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,6 @@
-aws-requests-auth==0.4.3
-chalice==1.26.2
-cryptography==35.0.0
 jinja2==3.0.2
-jwcrypto==1.0
 netaddr==0.8.0
 pyjwt==2.3.0
-pyOpenSSL==21.0.0 # maybe not necessary
-python-jose==3.3.0
 PyYAML==6.0
 
 pip>=19.2 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-jinja2==3.0.2
-netaddr==0.8.0
-pyjwt==2.3.0
-PyYAML==6.0
+jinja2>=3.0.0
+netaddr>=0.8.0
+pyjwt>=1.6.0
+PyYAML # all versions are compatible
 
 pip>=19.2 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
Over half were unused, the rest I tried to some degree to find the minimum compatible version. Jinja2 and netaddr can probably go lower but it doesn't really matter since the dependent projects should always be trying to use the latest version of everything anyways.