### PR TITLE
PR-3042 add crypto dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 jinja2>=3.0.0
 netaddr>=0.8.0
-pyjwt>=1.6.0
+pyjwt[crypto]>=1.6.0
 PyYAML # all versions are compatible
 
 pip>=19.2 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 jinja2>=3.0.0
 netaddr>=0.8.0
 pyjwt[crypto]>=1.6.0
-PyYAML # all versions are compatible
+pyyaml>=5.1
 
 pip>=19.2 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
Pyjwt needs the `crypto` extra for RSA support.