### PR TITLE
Add github actions for running unit tests and linters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: lint
+on:
+  pull_request:
+
+jobs:
+  flake8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - run: pip install -r requirements.txt
+
+      - uses: TrueBrain/actions-flake8@v2
+        with:
+          plugins: flake8-isort

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - devel
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt -r requirements-dev.txt
+
+    - run: pip install pytest-github-actions-annotate-failures
+
+    - run: py.test --cov=rain_api_core --cov-report=term-missing --cov-report=xml --cov-branch --doctest-modules rain_api_core tests
+
+    - name: Report coverage
+      uses: codecov/codecov-action@v2
+      with:
+        fail_ci_if_error: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.1%
+
+    patch:
+      default:
+        target: 85%

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
-pytest-cov==3.0.0
-pytest==6.2.5
+boto3
+pytest-cov
+pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[isort]
+multi_line_output = 3
+line_length = 120
+skip_gitignore = true
+
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
Mostly the same as for TEA, but the pytest command is modified to include doctests from the `rain_api_core` folder.

Would still need to add the codecov app to the repo to get the coverage diff statuses on PR's