### PR TITLE
Refactor JWT validation and URS api usage

### DIFF
--- a/rain_api_core/auth.py
+++ b/rain_api_core/auth.py
@@ -35,6 +35,18 @@ class UserProfile:
             exp=payload.get('exp')
         )
 
+    def to_jwt_payload(self):
+        return {
+            'urs-user-id': self.user_id,
+            'urs-access-token': self.token,
+            'urs-groups': self.groups,
+            'first_name': self.first_name,
+            'last_name': self.last_name,
+            'email': self.email,
+            'iat': self.iat,
+            'exp': self.exp,
+        }
+
 
 class JwtManager:
     def __init__(

--- a/rain_api_core/auth.py
+++ b/rain_api_core/auth.py
@@ -1,0 +1,134 @@
+import contextlib
+import dataclasses
+import logging
+from http.cookies import CookieError, SimpleCookie
+from time import time
+from typing import List, Mapping, Optional
+from wsgiref.handlers import format_date_time as format_7231_date
+
+import jwt
+
+log = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class UserProfile:
+    user_id: str
+    token: str
+    groups: List[str]
+    first_name: str
+    last_name: str
+    email: str
+    iat: int = None
+    exp: int = None
+
+    @classmethod
+    def from_jwt_payload(cls, payload):
+        return cls(
+            user_id=payload.get('urs-user-id'),
+            token=payload.get('urs-access-token'),
+            groups=payload.get('urs-groups'),
+            first_name=payload.get('first_name'),
+            last_name=payload.get('last_name'),
+            email=payload.get('email'),
+            iat=payload.get('iat'),
+            exp=payload.get('exp')
+        )
+
+
+class JwtManager:
+    def __init__(
+        self,
+        algorithm: str,
+        public_key: str,
+        private_key: str,
+        cookie_name: str,
+        blacklist={},
+        session_ttl_in_hours: int = 7 * 24
+    ):
+        self.algorithm = algorithm
+        self.public_key = public_key
+        self.private_key = private_key
+        self.cookie_name = cookie_name
+        self.session_ttl = session_ttl_in_hours * 60 * 60
+        self.black_list = blacklist
+
+    def _get_auth_cookie(self, headers: Mapping[str, str]):
+        cookie_string = headers.get('cookie') or headers.get('Cookie') or headers.get('COOKIE')
+        if not cookie_string:
+            return {}
+
+        cookie = SimpleCookie()
+        with contextlib.suppress(CookieError):
+            cookie.load(cookie_string)
+        return cookie.get(self.cookie_name)
+
+    def _decode_jwt(self, token: str):
+        try:
+            return jwt.decode(token.encode(), self.public_key, [self.algorithm])
+        except jwt.ExpiredSignatureError:
+            log.info('JWT has expired')
+        except jwt.InvalidSignatureError:
+            log.info('JWT has failed verification')
+        return None
+
+    def _encode_jwt(self, payload: Mapping[str, str]) -> str:
+        try:
+            encoded = jwt.encode(payload, self.private_key, self.algorithm)
+        except TypeError:
+            log.error('unable to encode jwt cookie')
+            return ''
+        return encoded
+
+    def _jwt_payload_from_user_profile(self, user_profile: Optional[UserProfile]):
+        if user_profile is None:
+            return {}
+        now = int(time())
+        return {
+            'urs-user-id': user_profile.user_id,
+            'first_name': user_profile.first_name,
+            'last_name': user_profile.last_name,
+            'email': user_profile.email,
+            'urs-access-token': user_profile.token,
+            'urs-groups': user_profile.groups,
+            'iat': now,
+            'exp': now + self.session_ttl
+        }
+
+    def _in_blacklist(self, user_profile: UserProfile):
+        assert user_profile.iat is not None
+        user_blacklist_time = self.black_list.get(user_profile.user_id)
+        if user_blacklist_time is not None:
+            if user_blacklist_time >= user_profile.iat:
+                return True
+        return False
+
+    def get_profile_from_headers(self, headers) -> Optional[UserProfile]:
+        """Inspects headers for auth cookie and return user_profile if authenticated, None otherwise"""
+        auth_cookie = self._get_auth_cookie(headers)
+        if not auth_cookie:
+            return None
+
+        jwt_decoded = self._decode_jwt(auth_cookie.value)
+
+        if jwt_decoded is None:
+            return None
+        user_profile = UserProfile.from_jwt_payload(jwt_decoded)
+        if self._in_blacklist(user_profile):
+            return None
+        return user_profile
+
+    def get_header_to_set_auth_cookie(self, user_profile: Optional[UserProfile], cookie_domain=''):
+        """ Gets a header to set auth-cookie
+
+        Parameters:
+        UserProfile: UserProfile to use in construction of a cookie, if none will return header to unset/logout
+        """
+        payload = self._jwt_payload_from_user_profile(user_profile)
+        cookie_value = self._encode_jwt(payload) if payload else 'expired'
+        cookie_domain = f'; Domain={cookie_domain}' if cookie_domain else ''
+        if payload:
+            expire_date = format_7231_date(payload['exp'])
+        else:
+            expire_date = 'Thu, 01 Jan 1970 00:00:00 GMT'
+        return {'SET-COOKIE': f'{self.cookie_name}={cookie_value}; Expires={expire_date}; Path=/{cookie_domain}'}

--- a/rain_api_core/urs_util.py
+++ b/rain_api_core/urs_util.py
@@ -4,11 +4,11 @@ import os
 import urllib
 from time import time
 
+from rain_api_core.auth import JwtManager, UserProfile
 from rain_api_core.aws_util import retrieve_secret
 from rain_api_core.general_util import duration, return_timing_object
 from rain_api_core.logging import log_context
 from rain_api_core.timer import Timer
-from rain_api_core.view_util import JWT_COOKIE_NAME, get_exp_time, make_set_cookie_headers_jwt
 
 log = logging.getLogger(__name__)
 
@@ -97,11 +97,22 @@ def get_urs_url(ctxt: dict, to: str = None) -> str:
     return urs_url
 
 
-def get_profile(user_id: str, token: str, temptoken: str = None, aux_headers: dict = None) -> dict:
+def get_user_profile(urs_user_payload: dict, access_token) -> UserProfile:
+    return UserProfile(
+        user_id=urs_user_payload['uid'],
+        token=access_token,
+        groups=urs_user_payload['user_groups'],
+        first_name=urs_user_payload['first_name'],
+        last_name=urs_user_payload['last_name'],
+        email=urs_user_payload['email_address'],
+    )
+
+
+def get_profile(user_id: str, token: str, temptoken: str = None, aux_headers: dict = None) -> UserProfile:
     aux_headers = aux_headers or {}  # Safer Default
 
     if not user_id or not token:
-        return {}
+        return None
 
     # get_new_token_and_profile() will pass this function a temporary token with which to fetch the profile info. We
     # don't want to keep it around, just use it here, once:
@@ -122,7 +133,7 @@ def get_profile(user_id: str, token: str, temptoken: str = None, aux_headers: di
         log.info(return_timing_object(service="EDL", endpoint=url, duration=duration(timer)))
         user_profile = json.loads(packet)
 
-        return user_profile
+        return get_user_profile(user_profile, headertoken)
 
     except urllib.error.URLError as e:
         log.warning("Error fetching profile: {0}".format(e))
@@ -220,36 +231,34 @@ def user_in_group_urs(private_groups, user_id, token, user_profile=None, refresh
     return False, new_profile
 
 
-def user_in_group(private_groups, cookievars, refresh_first=False, aux_headers=None):
+def user_in_group(private_groups, user_profile: UserProfile, refresh_first=False, aux_headers=None):
     aux_headers = aux_headers or {}  # A safer default
 
     # If a new profile is fetched, it is assigned to this var, and returned so that a fresh jwt cookie can be set.
-    new_profile = {}
+    new_profile = None
 
     if not private_groups:
         return False, new_profile
 
-    jwt_payload = cookievars.get(JWT_COOKIE_NAME)
-
-    if not jwt_payload:
+    if not user_profile:
         return False, new_profile
 
     if refresh_first:
-        new_profile = get_profile(jwt_payload['urs-user-id'], jwt_payload['urs-access-token'], aux_headers=aux_headers)
-        jwt_payload['urs-groups'] = new_profile['user_groups']
+        new_profile = get_profile(user_profile.user_id, user_profile.token, aux_headers=aux_headers)
+        user_profile.groups = new_profile.groups
 
-    in_group = user_in_group_list(private_groups, jwt_payload['urs-groups'])
+    in_group = user_in_group_list(private_groups, user_profile.groups)
     if in_group:
         return True, new_profile
 
     if not in_group and not refresh_first:
         # one last ditch effort to see if they were so very recently added to group:
-        jwt_payload['urs-groups'] = get_profile(
-            jwt_payload['urs-user-id'],
-            jwt_payload['urs-access-token'],
+        user_profile = get_profile(
+            user_profile.user_id,
+            user_profile.token,
             aux_headers=aux_headers
-        )['user_groups']
-        return user_in_group(private_groups, cookievars, refresh_first=True, aux_headers=aux_headers)
+        )
+        return user_in_group(private_groups, user_profile, refresh_first=True, aux_headers=aux_headers)
 
     return False, new_profile
 
@@ -277,21 +286,8 @@ def get_urs_creds() -> dict:
     return secret
 
 
-def user_profile_2_jwt_payload(user_id: str, access_token: str, user_profile: dict) -> dict:
-    return {
-        'first_name': user_profile['first_name'],
-        'last_name': user_profile['last_name'],
-        'email': user_profile['email_address'],
-        'urs-user-id': user_id,
-        'urs-access-token': access_token,
-        'urs-groups': user_profile['user_groups'],
-        'iat': int(time()),
-        'exp': get_exp_time(),
-    }
-
-
 # This do_login() is mainly for chalice clients.
-def do_login(args, context, cookie_domain='', aux_headers=None):
+def do_login(args, context, jwt_manager: JwtManager, cookie_domain='', aux_headers=None):
     aux_headers = aux_headers or {}  # A safer default
 
     log.debug('the query_params: {}'.format(args))
@@ -347,10 +343,8 @@ def do_login(args, context, cookie_domain='', aux_headers=None):
         if 'user_groups' not in user_profile:
             user_profile['user_groups'] = []
 
-        jwt_cookie_payload = user_profile_2_jwt_payload(user_id, auth['access_token'], user_profile)
-
         headers = {'Location': redirect_to}
-        headers.update(make_set_cookie_headers_jwt(jwt_cookie_payload, '', cookie_domain))
+        headers.update(jwt_manager.get_header_to_set_auth_cookie(UserProfile, cookie_domain))
         return 301, {}, headers
 
     template_vars = {'contentstring': 'Could not get user profile from URS', 'title': 'Could Not Login'}

--- a/rain_api_core/urs_util.py
+++ b/rain_api_core/urs_util.py
@@ -145,7 +145,7 @@ def get_profile(user_id: str, token: str, temptoken: str = None, aux_headers: di
             f"We got that 401 above and we're using a temptoken ({temptoken}), "
             "so giving up and not getting a profile."
         )
-    return {}
+    return None
 
 
 def get_new_token_and_profile(user_id: str, cookietoken: str, aux_headers: dict = None):
@@ -188,7 +188,7 @@ def get_new_token_and_profile(user_id: str, cookietoken: str, aux_headers: dict 
         log.error("Error fetching auth: %s", e)
         timer.mark()
         log.debug("ET for the attempt: %.4f", timer.total.duration())
-        return False
+        return None
 
 
 def user_in_group_list(private_groups: list, user_groups: list) -> bool:
@@ -333,18 +333,15 @@ def do_login(args, context, jwt_manager: JwtManager, cookie_domain='', aux_heade
 
     user_profile = get_profile(user_id, auth['access_token'], aux_headers={})
     log.debug('Got the user profile: {}'.format(user_profile))
-    if user_profile:
+    if user_profile is not None:
         log.debug('urs-access-token: {}'.format(auth['access_token']))
         if 'state' in args:
             redirect_to = args["state"]
         else:
             redirect_to = get_base_url(context)
 
-        if 'user_groups' not in user_profile:
-            user_profile['user_groups'] = []
-
         headers = {'Location': redirect_to}
-        headers.update(jwt_manager.get_header_to_set_auth_cookie(UserProfile, cookie_domain))
+        headers.update(jwt_manager.get_header_to_set_auth_cookie(user_profile, cookie_domain))
         return 301, {}, headers
 
     template_vars = {'contentstring': 'Could not get user profile from URS', 'title': 'Could Not Login'}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cachetools==5.0.0
 jinja2>=3.0.0
 netaddr>=0.8.0
 pyjwt[crypto]>=1.6.0

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,177 @@
+from unittest import mock
+
+import jwt
+import jwt.utils
+import pytest
+
+from rain_api_core.auth import JwtManager, UserProfile
+
+MODULE = 'rain_api_core.auth'
+
+
+@pytest.fixture
+def jwt_manager(jwt_priv_key, jwt_pub_key):
+    return JwtManager(
+        algorithm='RS256',
+        public_key=jwt_pub_key,
+        private_key=jwt_priv_key,
+        cookie_name='auth-cookie',
+    )
+
+
+def test_decode_jwt(jwt_manager, jwt_priv_key):
+    payload = {'foo': 'bar'}
+    encoded = jwt.encode(payload, jwt_priv_key, 'RS256')
+    assert jwt_manager._decode_jwt(encoded) == payload
+
+
+def test_decode_jwt_expired(jwt_manager, jwt_priv_key):
+    payload = {'foo': 'bar', 'exp': 0}
+    encoded = jwt.encode(payload, jwt_priv_key, 'RS256')
+    assert jwt_manager._decode_jwt(encoded) is None
+
+
+def test_decode_jwt_invalid(jwt_manager, jwt_priv_key):
+    encoded = b".".join((
+        jwt.utils.base64url_encode(b'{"alg": "RS256"}'),
+        jwt.utils.base64url_encode(b'{"not valid'),
+        jwt.utils.base64url_encode(b"some bytes"),
+    )).decode()
+    assert jwt_manager._decode_jwt(encoded) is None
+
+
+def test_get_auth_cookie(jwt_manager):
+    jwt_manager.cookie_name = 'auth-cookie'
+
+    headers = {'Cookie': 'auth-cookie=foo'}
+    assert jwt_manager._get_auth_cookie(headers).value == 'foo'
+    headers = {'Cookie': 'auth-cookie=foo; not-auth-cookie=bar'}
+    assert jwt_manager._get_auth_cookie(headers).value == 'foo'
+    headers = {'Cookie': 'not-auth-cookie=foo'}
+    assert jwt_manager._get_auth_cookie(headers) is None
+
+
+def test_in_blacklist(jwt_manager):
+    jwt_manager.black_list = {
+        'blacklisted_user': 100,
+    }
+
+    profile = UserProfile(
+        user_id='blacklisted_user',
+        token='test_token',
+        groups=['test_group1', 'test_group2'],
+        first_name='test_first_name',
+        last_name='test_last_name',
+        email='test_email',
+        iat=75
+    )
+    assert jwt_manager._in_blacklist(profile) is True
+    profile.iat = 115
+    assert jwt_manager._in_blacklist(profile) is False
+
+
+@mock.patch(f'{MODULE}.time', autospec=True)
+def test_jwt_payload_from_user_profile(mock_time, jwt_manager):
+    profile = UserProfile(
+        user_id='test_user_id',
+        token='test_token',
+        groups=['test_group1', 'test_group2'],
+        first_name='test_first_name',
+        last_name='test_last_name',
+        email='test_email',
+    )
+    mock_time.return_value = 1
+
+    jwt_manager.session_ttl = 5
+    payload = jwt_manager._jwt_payload_from_user_profile(profile)
+
+    assert payload == {
+        'urs-user-id': 'test_user_id',
+        'first_name': 'test_first_name',
+        'last_name': 'test_last_name',
+        'email': 'test_email',
+        'urs-access-token': 'test_token',
+        'urs-groups': ['test_group1', 'test_group2'],
+        'iat': 1,
+        'exp': 6
+    }
+
+
+@mock.patch(f'{MODULE}.JwtManager._in_blacklist', autospec=True)
+def test_get_profile_from_header(mock_in_blacklist, jwt_manager, jwt_priv_key):
+    mock_in_blacklist.return_value = False
+    payload = {
+        'urs-user-id': 'test_user',
+        'first_name': 'test',
+        'last_name': 'user',
+        'email': 'user@emailwebsite.com',
+        'urs-access-token': 'foo',
+        'urs-groups': []
+    }
+
+    headers = {
+        'Cookie': f'auth-cookie={jwt.encode(payload, jwt_priv_key, "RS256")}'
+    }
+    user_profile = jwt_manager.get_profile_from_headers(headers)
+    assert user_profile.user_id == 'test_user'
+
+    headers = {}
+    assert jwt_manager.get_profile_from_headers(headers) is None
+
+
+@mock.patch(f'{MODULE}.JwtManager._in_blacklist', autospec=True)
+def test_get_profile_from_header_jwt_blacklisted(mock_in_blacklist, jwt_manager, jwt_priv_key):
+    mock_in_blacklist.return_value = True
+    payload = {
+        'urs-user-id': 'test_user',
+        'first_name': 'test',
+        'last_name': 'user',
+        'email': 'user@emailwebsite.com',
+        'urs-access-token': 'foo',
+        'urs-groups': []
+    }
+
+    headers = {
+        'Cookie': f'auth-cookie={jwt.encode(payload, jwt_priv_key, "RS256")}'
+    }
+    user_profile = jwt_manager.get_profile_from_headers(headers)
+    assert user_profile is None
+
+
+@mock.patch(f'{MODULE}.JwtManager._encode_jwt', autospec=True)
+@mock.patch(f'{MODULE}.time', autospec=True)
+def test_get_header_to_set_auth_cookie(
+    mock_time,
+    mock_encode_jwt,
+    jwt_manager,
+    jwt_priv_key,
+):
+    jwt_manager.cookie_name = 'auth-cookie'
+    jwt_manager.session_ttl = 1
+
+    mock_encode_jwt.return_value = 'COOKIE_VALUE'
+    mock_time.return_value = 0
+
+    profile = UserProfile(
+        user_id='test_user_id',
+        token='test_token',
+        groups=['test_group1', 'test_group2'],
+        first_name='test_first_name',
+        last_name='test_last_name',
+        email='test_email',
+        iat=0,
+        exp=0
+    )
+
+    header = jwt_manager.get_header_to_set_auth_cookie(profile, '')
+    assert header == {'SET-COOKIE': 'auth-cookie=COOKIE_VALUE; Expires=Thu, 01 Jan 1970 00:00:01 GMT; Path=/'}
+
+    header = jwt_manager.get_header_to_set_auth_cookie(profile, 'DOMAIN')
+    assert header == {
+        'SET-COOKIE': 'auth-cookie=COOKIE_VALUE; Expires=Thu, 01 Jan 1970 00:00:01 GMT; Path=/; Domain=DOMAIN'
+    }
+
+
+def test_get_header_to_set_auth_cookie_logout(jwt_manager):
+    header = jwt_manager.get_header_to_set_auth_cookie(None, 'DOMAIN')
+    assert header == {'SET-COOKIE': 'auth-cookie=expired; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Domain=DOMAIN'}

--- a/tests/test_urs_util.py
+++ b/tests/test_urs_util.py
@@ -331,7 +331,6 @@ def test_do_login(
     )
 
 
-
 @mock.patch(f"{MODULE}.do_auth", autospec=True)
 def test_do_login_failed_auth(mock_do_auth, context):
     mock_do_auth.return_value = {}

--- a/tests/test_urs_util.py
+++ b/tests/test_urs_util.py
@@ -1,8 +1,10 @@
+import json
 import urllib
 from unittest import mock
 
 import pytest
 
+from rain_api_core.auth import JwtManager, UserProfile
 from rain_api_core.urs_util import (
     do_auth,
     do_login,
@@ -14,8 +16,7 @@ from rain_api_core.urs_util import (
     get_urs_url,
     user_in_group,
     user_in_group_list,
-    user_in_group_urs,
-    user_profile_2_jwt_payload
+    user_in_group_urs
 )
 
 MODULE = "rain_api_core.urs_util"
@@ -110,13 +111,25 @@ def test_get_urs_url(mock_get_urs_creds, context):
 @mock.patch(f"{MODULE}.urllib.request", autospec=True)
 def test_get_profile(mock_request):
     mock_response = mock.NonCallableMock()
-    mock_response.read.return_value = '{"foo": "bar"}'
+    mock_response.read.return_value = json.dumps(
+        {
+            "uid": "user_id",
+            "first_name": "John",
+            "last_name": "Smith",
+            "email_address": "peter.l.smith@nasa.gov",
+            "user_groups": []
+        }
+    )
     mock_request.urlopen.return_value = mock_response
 
-    assert get_profile("user_id", "token") == {"foo": "bar"}
-    assert get_profile("user_id", "token", "temptoken") == {"foo": "bar"}
-    assert get_profile(None, "token") == {}
-    assert get_profile("user_id", None) == {}
+    profile = get_profile("user_id", "token")
+    assert profile.user_id == "user_id"
+    assert profile.first_name == "John"
+
+    profile = get_profile("user_id", "token", "temptoken")
+    assert profile.user_id == "user_id"
+    assert get_profile(None, "token") is None
+    assert get_profile("user_id", None) is None
 
 
 @mock.patch(f"{MODULE}.urllib.request", autospec=True)
@@ -202,11 +215,20 @@ def test_user_in_group_urs(mock_get_profile, mock_user_in_group_list):
 def test_user_in_group(mock_user_in_group_list):
     mock_user_in_group_list.return_value = True
 
-    assert user_in_group([], {}) == (False, {})
+    user = UserProfile(
+        user_id='test_user_id',
+        token='test_token',
+        groups=[],
+        first_name='test_first_name',
+        last_name='test_last_name',
+        email='test_email',
+    )
+
+    assert user_in_group([], {}) == (False, None)
     mock_user_in_group_list.assert_not_called()
-    assert user_in_group(["GROUP_1"], {"asf-urs": {}}) == (False, {})
+    assert user_in_group(["GROUP_1"], None) == (False, None)
     mock_user_in_group_list.assert_not_called()
-    assert user_in_group(["GROUP_1"], {"asf-urs": {"urs-groups": []}}) == (True, {})
+    assert user_in_group(["GROUP_1"], user) == (True, None)
     mock_user_in_group_list.assert_called_once()
 
 
@@ -214,20 +236,21 @@ def test_user_in_group(mock_user_in_group_list):
 @mock.patch(f"{MODULE}.get_profile", autospec=True)
 def test_user_in_group_refresh(mock_get_profile, mock_user_in_group_list):
     mock_user_in_group_list.return_value = True
-    mock_get_profile.return_value = {"user_groups": []}
-    cookievars = {
-        "asf-urs": {
-            "urs-user-id": "user_id",
-            "urs-access-token": "access_token",
-            "urs-groups": []
-        }
-    }
+    user = UserProfile(
+        user_id='test_user_id',
+        token='test_token',
+        groups=[],
+        first_name='test_first_name',
+        last_name='test_last_name',
+        email='test_email',
+    )
+    mock_get_profile.return_value = user
 
-    assert user_in_group(["GROUP_1"], cookievars, refresh_first=True) == (True, {"user_groups": []})
+    assert user_in_group(["GROUP_1"], user, refresh_first=True) == (True, user)
     mock_user_in_group_list.assert_called_once()
 
     mock_user_in_group_list.return_value = False
-    assert user_in_group(["GROUP_1"], cookievars, refresh_first=False) == (False, {"user_groups": []})
+    assert user_in_group(["GROUP_1"], user, refresh_first=False) == (False, user)
 
 
 @mock.patch(f"{MODULE}.retrieve_secret", autospec=True)
@@ -247,41 +270,14 @@ def test_get_urs_creds(mock_retrieve_secret, monkeypatch):
     assert get_urs_creds() == secret
 
 
-@mock.patch(f"{MODULE}.time", autospec=True)
-@mock.patch(f"{MODULE}.get_exp_time", autospec=True)
-def test_user_profile_2_jwt_payload(mock_get_exp_time, mock_time):
-    mock_time.return_value = 0
-    mock_get_exp_time.return_value = 1000
-
-    user_profile = {
-        "first_name": "First",
-        "last_name": "Last",
-        "email_address": "email@domain.com",
-        "user_groups": []
-    }
-
-    assert user_profile_2_jwt_payload("user_id", "access_token", user_profile) == {
-        "first_name": "First",
-        "last_name": "Last",
-        "email": "email@domain.com",
-        "urs-user-id": "user_id",
-        "urs-access-token": "access_token",
-        "urs-groups": [],
-        "iat": 0,
-        "exp": 1000,
-    }
-
-
 @mock.patch(f"{MODULE}.do_auth", autospec=True)
 @mock.patch(f"{MODULE}.get_profile", autospec=True)
-@mock.patch(f"{MODULE}.user_profile_2_jwt_payload", autospec=True)
-@mock.patch(f"{MODULE}.make_set_cookie_headers_jwt", autospec=True)
+@mock.patch(f"{MODULE}.JwtManager.get_header_to_set_auth_cookie", autospec=True)
 def test_do_login(
-    mock_make_set_cookie_headers_jwt,
-    mock_user_profile_2_jwt_payload,
-    mock_get_profile,
-    mock_do_auth,
-    context
+        mock_get_header_to_set_auth_cookie,
+        mock_get_profile,
+        mock_do_auth,
+        context
 ):
     mock_do_auth.return_value = {
         "endpoint": "ENDPOINT",
@@ -290,14 +286,15 @@ def test_do_login(
     mock_get_profile.return_value = {
         "user_groups": ["GROUP_1"]
     }
-    mock_make_set_cookie_headers_jwt.return_value = {
+    mock_get_header_to_set_auth_cookie.return_value = {
         "SET-COOKIE": "foo=bar"
     }
 
     args = {
         "code": "URS_CODE"
     }
-    assert do_login(args, context) == (
+    jwt_manager = JwtManager('algorithm', 'pub_key', 'priv_key', 'cookie-name')
+    assert do_login(args, context, jwt_manager) == (
         301,
         {},
         {
@@ -310,7 +307,7 @@ def test_do_login(
         "code": "URS_CODE",
         "state": "https://somewhere-else.com"
     }
-    assert do_login(args, context) == (
+    assert do_login(args, context, jwt_manager) == (
         301,
         {},
         {
@@ -322,7 +319,7 @@ def test_do_login(
     mock_get_profile.return_value = {
         "foo": "bar"
     }
-    assert do_login(args, context) == (
+    assert do_login(args, context, jwt_manager) == (
         301,
         {},
         {
@@ -335,8 +332,9 @@ def test_do_login(
 @mock.patch(f"{MODULE}.do_auth", autospec=True)
 def test_do_login_failed_auth(mock_do_auth, context):
     mock_do_auth.return_value = {}
+    jwt_manager = JwtManager('algorithm', 'pub_key', 'priv_key', 'cookie-name')
 
-    assert do_login({"code": "URS_CODE"}, context) == (
+    assert do_login({"code": "URS_CODE"}, context, jwt_manager) == (
         400,
         {
             "contentstring": "There was a problem talking to URS Login",
@@ -354,8 +352,9 @@ def test_do_login_failed_profile(mock_get_profile, mock_do_auth, context):
         "access_token": "ACCESS_TOKEN"
     }
     mock_get_profile.return_value = {}
+    jwt_manager = JwtManager('algorithm', 'pub_key', 'priv_key', 'cookie-name')
 
-    assert do_login({"code": "URS_CODE"}, context) == (
+    assert do_login({"code": "URS_CODE"}, context, jwt_manager) == (
         400,
         {
             "contentstring": "Could not get user profile from URS",
@@ -366,7 +365,8 @@ def test_do_login_failed_profile(mock_get_profile, mock_do_auth, context):
 
 
 def test_do_login_error():
-    assert do_login({}, {}) == (
+    jwt_manager = JwtManager('algorithm', 'pub_key', 'priv_key', 'cookie-name')
+    assert do_login({}, {}, jwt_manager) == (
         400,
         {
             "contentstring": "No params",
@@ -374,7 +374,8 @@ def test_do_login_error():
         },
         {}
     )
-    assert do_login({"error": "URS_ERROR"}, {}) == (
+
+    assert do_login({"error": "URS_ERROR"}, {}, jwt_manager) == (
         400,
         {
             "contentstring": 'An error occurred while trying to log into URS. URS says: "URS_ERROR". ',
@@ -382,7 +383,7 @@ def test_do_login_error():
         },
         {}
     )
-    assert do_login({"error": "access_denied"}, {}) == (
+    assert do_login({"error": "access_denied"}, {}, jwt_manager) == (
         401,
         {
             "contentstring": "Be sure to agree to the EULA.",
@@ -391,7 +392,7 @@ def test_do_login_error():
         },
         {}
     )
-    assert do_login({"foo": "bar"}, {}) == (
+    assert do_login({"foo": "bar"}, {}, jwt_manager) == (
         400,
         {
             "contentstring": "Did not get the required CODE from URS",


### PR DESCRIPTION
Adds new module `auth.py` which implements `JwtManager` `UrsManager` and `UserProfile` classes

`UserProfile` Dataclass that holds information about the logged in user

`JwtManager` Class for handling Jwt validation and cookie read/write
 - `get_profile_from_headers` take headers as dict and return `UserProfile` if logged in with a valid session, None otherwise. (handles blacklist)

- `get_header_to_set_auth_cookie` takes a UserProfile (or `None` and returns a header that will set the auth cookie, If `None` will return the header to erase the cookie.


functions in `urs_util.py` now return UserProfile instead of dict, where empty dict was used for no user, now None is given