### PR TITLE
PR-3224 Add log censor for flat logger

### DIFF
--- a/rain_api_core/logging.py
+++ b/rain_api_core/logging.py
@@ -34,7 +34,7 @@ def get_log():
     loglevel = os.getenv('LOGLEVEL', 'INFO')
     logtype = os.getenv('LOGTYPE', 'json')
     if logtype == 'flat':
-        formatter = logging.Formatter(
+        formatter = LogCensorFormatter(
             "%(levelname)s: %(message)s (%(filename)s line %(lineno)d/%(build_vers)s/%(maturity)s) - "
             "RequestId: %(request_id)s; OriginRequestId: %(origin_request_id)s; user_id: %(user_id)s; route: %(route)s"
         )
@@ -157,6 +157,11 @@ class JSONPercentStyle():
             return self._format(record)
         except KeyError as e:
             raise ValueError(f"Formatting field not found in record: {e}")
+
+
+class LogCensorFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        return filter_log_credentials(super().format(record))
 
 
 class JSONFormatter(logging.Formatter):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -69,7 +69,7 @@ def test_get_log(capsys, monkeypatch):
     # Reset the root logger
     monkeypatch.setattr(logging, "root", logging.RootLogger(logging.WARNING))
     log = get_log()
-    log.info("test message: %s", 100)
+    log.info("test message: %s, Creds: %s", 100, "Basic ABCD")
 
     # NOTE: Adding any logging or print statements into custom logging internals may cause this test to fail
     stdout, _ = capsys.readouterr()
@@ -82,7 +82,7 @@ def test_get_log(capsys, monkeypatch):
         "level": "INFO",
         "RequestId": None,
         "OriginRequestId": None,
-        "message": "test message: 100",
+        "message": "test message: 100, Creds: Basic XXX<BASICAUTH>XXX",
         "maturity": "DEV",
         "user_id": None,
         "route": None,
@@ -163,12 +163,12 @@ def test_get_log_flat(capsys, monkeypatch):
     monkeypatch.setenv("LOGTYPE", "flat")
 
     log = get_log()
-    log.info("test message: %s", 100)
+    log.info("test message: %s, Creds: %s", 100, "Basic ABCD")
 
     # NOTE: Adding any logging or print statements into custom logging internals may cause this test to fail
     stdout, _ = capsys.readouterr()
     assert re.match(
-        r"INFO: test message: 100 \([a-z_]+.py line [0-9]+/NOBUILD/DEV\) - "
+        r"INFO: test message: 100, Creds: Basic XXX<BASICAUTH>XXX \([a-z_]+.py line [0-9]+/NOBUILD/DEV\) - "
         "RequestId: None; OriginRequestId: None; user_id: None; route: None\n",
         stdout
     )


### PR DESCRIPTION
When flat logging was enabled the log censor wasn't being called.