### PR TITLE
Adjust for pyjwt change in header key order

### DIFF
--- a/rain_api_core/logging.py
+++ b/rain_api_core/logging.py
@@ -8,7 +8,7 @@ UNCENSORED_LOGGING = os.getenv("UNCENSORED_LOGGING")
 
 LOG_CENSOR = [
     {
-        "regex": r"(eyJ0e[A-Za-z0-9-_]{10})[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*([A-Za-z0-9-_]{10})",
+        "regex": r"(eyJ[A-Za-z0-9-_]{12})[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*([A-Za-z0-9-_]{10})",
         "replace": "\\g<1>XXX<JWTTOKEN>XXX\\g<2>",
         "description": "X-out JWT Token payload"
     },

--- a/tests/test_view_util.py
+++ b/tests/test_view_util.py
@@ -230,7 +230,7 @@ def test_make_jwt_payload(mock_get_jwt_keys, jwt_priv_key):
     encoded = make_jwt_payload({"foo": "bar"})
 
     header, payload, signature = encoded.split(".")
-    assert urlsafe_b64decode(header + "==") == b'{"typ":"JWT","alg":"RS256"}'
+    assert urlsafe_b64decode(header + "==") == b'{"alg":"RS256","typ":"JWT"}'
     assert urlsafe_b64decode(payload + "==") == b'{"foo":"bar"}'
 
 


### PR DESCRIPTION
Headers are now encoded using `sort_keys` so that `alg` comes first. I adjusted the filter regex to look for base64 encoded `{"` so it should work for both old and new tokens.

See issue https://github.com/jpadilla/pyjwt/issues/715