### PR TITLE
PR-3244 Fix S3 policy duplicate generation

### DIFF
--- a/rain_api_core/bucket_map.py
+++ b/rain_api_core/bucket_map.py
@@ -241,15 +241,17 @@ class IamPolicyGenerator:
         return _is_accessible(required_groups, self.groups)
 
     def generate_policy(self, entries: Iterable[BucketMapEntry]) -> dict:
+        full_access_buckets = set()
         full_access_entries = []
         partial_access_entries = []
 
         for entry in entries:
             if self._is_whole_bucket_accessible(entry):
-                collection = full_access_entries
+                if entry.bucket not in full_access_buckets:
+                    full_access_entries.append(entry)
+                    full_access_buckets.add(entry.bucket)
             else:
-                collection = partial_access_entries
-            collection.append(entry)
+                partial_access_entries.append(entry)
 
         full_access_statement = ({
             "Effect": "Allow",

--- a/rain_api_core/bucket_map.py
+++ b/rain_api_core/bucket_map.py
@@ -241,33 +241,24 @@ class IamPolicyGenerator:
         return _is_accessible(required_groups, self.groups)
 
     def generate_policy(self, entries: Iterable[BucketMapEntry]) -> dict:
-        full_access_buckets = set()
-        full_access_entries = []
+        full_access_statement = _IamStatement(effect="Allow", action=self.permissions)
         partial_access_entries = []
 
         for entry in entries:
             if self._is_whole_bucket_accessible(entry):
-                if entry.bucket not in full_access_buckets:
-                    full_access_entries.append(entry)
-                    full_access_buckets.add(entry.bucket)
+                full_access_statement.add_resource(f"arn:aws:s3:::{entry.bucket}")
+                full_access_statement.add_resource(f"arn:aws:s3:::{entry.bucket}/*")
             else:
                 partial_access_entries.append(entry)
 
-        full_access_statement = ({
-            "Effect": "Allow",
-            "Action": self.permissions,
-            "Resource": [
-                resource
-                for entry in full_access_entries
-                for resource in (
-                    f"arn:aws:s3:::{entry.bucket}",
-                    f"arn:aws:s3:::{entry.bucket}/*"
-                )
-            ]
-        },) if full_access_entries else ()
+        full_access_statement_tuple = (
+            (full_access_statement.to_dict(),)
+            if full_access_statement.resource
+            else ()
+        )
 
         statement = [
-            *full_access_statement,
+            *full_access_statement_tuple,
             *(
                 statement
                 for entry in partial_access_entries
@@ -279,16 +270,16 @@ class IamPolicyGenerator:
             "Statement": statement or [
                 # Special case noop statement that will never match anything.
                 # We need this because IAM doesn't allow empty statement lists
-                {
-                    "Effect": "Allow",
-                    "Action": self.permissions,
-                    "Resource": ["*"],
-                    "Condition": {
+                _IamStatement(
+                    effect="Allow",
+                    action=self.permissions,
+                    resource=["*"],
+                    condition={
                         "StringNotLike": {
                             "s3:prefix": [""]
                         }
                     }
-                }
+                ).to_dict()
             ]
         }
 
@@ -307,18 +298,17 @@ class IamPolicyGenerator:
         assert entry._access_control, "Public buckets should be handled already"
 
         for condition in self._generate_iam_conditions(entry._access_control):
-            statement = {
-                "Effect": "Allow",
-                "Action": self.permissions,
-                "Resource": [
+            statement = _IamStatement(
+                effect="Allow",
+                action=self.permissions,
+                resource=[
                     f"arn:aws:s3:::{entry.bucket}",
                     f"arn:aws:s3:::{entry.bucket}/*"
-                ]
-            }
-            if condition:
-                statement["Condition"] = condition
+                ],
+                condition=condition
+            )
 
-            yield statement
+            yield statement.to_dict()
 
     def _generate_iam_conditions(self, access_control: dict) -> Generator[dict, None, None]:
         conditions = self._generate_string_match_conditions(access_control)
@@ -399,3 +389,44 @@ class IamPolicyGenerator:
             )
             for not_like, like in allowed_intervals_endpoints.items()
         )
+
+
+class _IamStatement:
+    """A helper for generating valid IAM statements"""
+
+    def __init__(
+        self,
+        effect: Optional[str] = None,
+        action: Iterable[str] = (),
+        resource: Iterable[str] = (),
+        condition: Optional[dict] = None,
+    ):
+        self.effect = effect
+        # Using dict instead of set because sets are unordered.
+        self.action = dict((val, None) for val in action)
+        self.resource = dict((val, None) for val in resource)
+        self.condition = condition
+
+    def add_action(self, value: str):
+        self.action[value] = None
+
+    def add_resource(self, value: str):
+        self.resource[value] = None
+
+    def to_dict(self) -> dict:
+        if not self.effect:
+            raise ValueError("'effect' must have a value")
+        if not self.action:
+            raise ValueError("'action' must have a value")
+        if not self.resource:
+            raise ValueError("'resource' must have a value")
+
+        statement = {
+            "Effect": self.effect,
+            "Action": list(self.action),
+            "Resource": list(self.resource)
+        }
+        if self.condition is not None:
+            statement["Condition"] = self.condition
+
+        return statement

--- a/tests/test_bucket_map.py
+++ b/tests/test_bucket_map.py
@@ -468,41 +468,13 @@ def test_get_required_groups(sample_bucket_map):
 def test_to_iam_policy_empty():
     b_map = BucketMap({})
 
-    assert b_map.to_iam_policy() == {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Action": ["s3:GetObject", "s3:ListBucket"],
-                "Resource": ["*"],
-                "Condition": {
-                    "StringNotLike": {
-                        "s3:prefix": [""]
-                    }
-                }
-            }
-        ]
-    }
+    assert b_map.to_iam_policy() is None
 
 
 def test_to_iam_policy_empty_permissions():
     b_map = BucketMap({})
 
-    assert b_map.to_iam_policy(permissions=("s3:ListBucket",)) == {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Action": ["s3:ListBucket"],
-                "Resource": ["*"],
-                "Condition": {
-                    "StringNotLike": {
-                        "s3:prefix": [""]
-                    }
-                }
-            }
-        ]
-    }
+    assert b_map.to_iam_policy(permissions=("s3:ListBucket",)) is None
 
 
 def test_to_iam_policy_simple():
@@ -584,23 +556,7 @@ def test_to_iam_policy_private():
     }
     b_map = BucketMap(bucket_map)
 
-    # This statement is effectively a deny-all without being an explicity Deny
-    # since it is effectively asserting `not "anything".startswith("")`
-    assert b_map.to_iam_policy(groups=()) == {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Action": ["s3:GetObject", "s3:ListBucket"],
-                "Resource": ["*"],
-                "Condition": {
-                    "StringNotLike": {
-                        "s3:prefix": [""]
-                    }
-                }
-            }
-        ]
-    }
+    assert b_map.to_iam_policy(groups=()) is None
 
 
 def test_to_iam_policy_private_with_public_prefix():
@@ -1023,21 +979,7 @@ def test_to_iam_policy(sample_bucket_map):
 def test_to_iam_policy_groups_noaccess(groups_bucket_map, groups):
     b_map = BucketMap(groups_bucket_map)
 
-    assert b_map.to_iam_policy(groups=groups) == {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Action": ["s3:GetObject", "s3:ListBucket"],
-                "Resource": ["*"],
-                "Condition": {
-                    "StringNotLike": {
-                        "s3:prefix": [""]
-                    }
-                }
-            }
-        ]
-    }
+    assert b_map.to_iam_policy(groups=groups) is None
 
 
 def test_to_iam_policy_groups_single_access(groups_bucket_map):

--- a/tests/test_bucket_map.py
+++ b/tests/test_bucket_map.py
@@ -547,6 +547,34 @@ def test_to_iam_policy_simple_permissions():
     }
 
 
+def test_to_iam_policy_simple_duplicates():
+    bucket_map = {
+        "PATH1": "bucket-name1",
+        "PATH2": "bucket-name1",
+        "PATH3": "bucket-name1",
+        "PATH4": "bucket-name2",
+        "PATH5": "bucket-name2",
+        "PATH6": "bucket-name2",
+    }
+    b_map = BucketMap(bucket_map)
+
+    assert b_map.to_iam_policy(groups=()) == {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": ["s3:GetObject", "s3:ListBucket"],
+                "Resource": [
+                    "arn:aws:s3:::bucket-name1",
+                    "arn:aws:s3:::bucket-name1/*",
+                    "arn:aws:s3:::bucket-name2",
+                    "arn:aws:s3:::bucket-name2/*"
+                ]
+            }
+        ]
+    }
+
+
 def test_to_iam_policy_private():
     bucket_map = {
         "PATH": "bucket-name",


### PR DESCRIPTION
Dedupe resources in `Resource` lists to keep the policy size small. I also changed the behavior to return None instead of a nomatch policy when a user has no permissions to access any data.

I think the 'noop' policy that I had was actually wrong because the `s3:prefix` match doesn't work the way I thought it did. I still need to test this a bit to confirm though.