### PR TITLE
PR-3244 Fix policy generation and simplify bucket access rules

### DIFF
--- a/extra/policy_gen_sandbox.py
+++ b/extra/policy_gen_sandbox.py
@@ -1,0 +1,56 @@
+import json
+import tkinter as tk
+import traceback
+
+import yaml
+
+from rain_api_core.bucket_map import BucketMap
+
+
+def main():
+    window = tk.Tk()
+    window.title("IAM Policy Generator Sandbox")
+    window.columnconfigure([0, 1], weight=1)
+    window.rowconfigure(0, minsize=800, weight=1)
+
+    frm_bucketmap = tk.Frame()
+    tk.Label(frm_bucketmap, text="Bucket map YAML").pack()
+    txt_bucketmap = tk.Text(frm_bucketmap)
+
+    def handle_text():
+        text = txt_bucketmap.get("1.0", tk.END)
+        try:
+            bucket_map = yaml.safe_load(text)
+            if bucket_map is None:
+                return
+            b_map = BucketMap(bucket_map)
+
+            policy = b_map.to_iam_policy()
+            policy_text = json.dumps(policy, indent=2)
+            txt_policy.delete("1.0", tk.END)
+            txt_policy.insert(tk.END, policy_text)
+        except Exception:
+            exc_text = traceback.format_exc()
+            txt_policy.delete("1.0", tk.END)
+            txt_policy.insert(tk.END, exc_text)
+
+    txt_bucketmap.bind(
+        "<Key>",
+        lambda _: window.after(1, handle_text)
+    )
+
+    txt_bucketmap.pack(expand=True, fill=tk.BOTH)
+    frm_bucketmap.grid(row=0, column=0, sticky="nsew")
+
+    frm_policy = tk.Frame()
+    tk.Label(frm_policy, text="Policy JSON").pack()
+    txt_policy = tk.Text(frm_policy)
+
+    txt_policy.pack(expand=True, fill=tk.BOTH)
+    frm_policy.grid(row=0, column=1, sticky="nsew")
+
+    window.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/rain_api_core/bucket_map.py
+++ b/rain_api_core/bucket_map.py
@@ -135,14 +135,10 @@ class BucketMap():
                 headers=headers
             )
 
-    def to_iam_policy(
-        self,
-        groups: Iterable[str] = None,
-        permissions: Iterable[str] = ("s3:GetObject", "s3:ListBucket")
-    ) -> dict:
+    def to_iam_policy(self, groups: Iterable[str] = None) -> dict:
         if not self._iam_compatible:
             _check_iam_compatible(self.access_control)
-        generator = IamPolicyGenerator(groups, permissions)
+        generator = IamPolicyGenerator(groups)
         return generator.generate_policy(self.entries())
 
     def _get_map(self) -> dict:
@@ -298,150 +294,92 @@ def _access_text(access) -> str:
 
 
 class IamPolicyGenerator:
-    def __init__(self, groups: Iterable[str], permissions: Iterable[str]):
+    def __init__(self, groups: Iterable[str]):
         self.groups = groups
-        self.permissions = list(permissions)
 
     def _is_accessible(self, required_groups: Optional[set]) -> bool:
         return _is_accessible(required_groups, self.groups)
 
     def generate_policy(self, entries: Iterable[BucketMapEntry]) -> Optional[dict]:
-        full_access_statement = _IamStatement(effect="Allow", action=self.permissions)
-        partial_access_entries = []
+        # Dedupe across buckets
+        bucket_access = {
+            entry.bucket: entry._access_control
+            for entry in entries
+        }
 
-        for entry in entries:
-            if self._is_whole_bucket_accessible(entry):
-                full_access_statement.add_resource(f"arn:aws:s3:::{entry.bucket}")
-                full_access_statement.add_resource(f"arn:aws:s3:::{entry.bucket}/*")
-            else:
-                partial_access_entries.append(entry)
+        get_object_statement = _IamStatement(effect="Allow", action=["s3:GetObject"])
+        list_bucket_prefixes = defaultdict(list)
+        for bucket, access_control in bucket_access.items():
+            consolidated = self._consolidate_access_rules(access_control)
 
-        full_access_statement_tuple = (
-            (full_access_statement.to_dict(),)
-            if full_access_statement.resource
-            else ()
-        )
+            for key_prefix, _ in reversed(consolidated.items()):
+                if key_prefix:
+                    list_bucket_prefixes[key_prefix].append(bucket)
+                else:
+                    get_object_statement.add_action("s3:ListBucket")
+                    get_object_statement.add_resource(f"arn:aws:s3:::{bucket}")
 
-        statement = [
-            *full_access_statement_tuple,
-            *(
-                statement
-                for entry in partial_access_entries
-                for statement in self._generate_iam_statements(entry)
-            )
-        ]
-        if not statement:
+                get_object_statement.add_resource(f"arn:aws:s3:::{bucket}/{key_prefix}*")
+
+        if not get_object_statement.resource:
             return None
+
+        # Merge prefixes when all resources match
+        list_bucket_conditions = defaultdict(list)
+        for prefix, buckets in list_bucket_prefixes.items():
+            list_bucket_conditions[tuple(sorted(buckets))].append(prefix)
 
         return {
             "Version": "2012-10-17",
-            "Statement": statement
+            "Statement": [
+                get_object_statement.to_dict(),
+                *(
+                    _IamStatement(
+                        effect="Allow",
+                        action=["s3:ListBucket"],
+                        resource=[f"arn:aws:s3:::{bucket}" for bucket in buckets],
+                        condition={
+                            "StringLike": {
+                                "s3:prefix": [f"{prefix}*" for prefix in prefixes]
+                            }
+                        }
+                    ).to_dict()
+                    for buckets, prefixes in list_bucket_conditions.items()
+                )
+            ]
         }
 
-    def _is_whole_bucket_accessible(self, entry: BucketMapEntry) -> bool:
-        if entry._access_control is None:
-            return True
+    def _consolidate_access_rules(self, access_control: Optional[dict]) -> dict:
+        """Removes redundant rules by finding the shortest prefixes that
+        are accessible.
 
-        return all(
-            self._is_accessible(required_groups)
-            for required_groups in entry._access_control.values()
-        )
+        For example if our access rules look like this:
+        {
+            "key1/foo/bar": None,
+            "key1/bar/baz": set(),
+            "key1/": {"group", "group2"},
+            "key2/": {"group", "group2", "group3"},
+            "key3/": {"group2", "group3"},
+            "": {"group2"}
+        }
 
-    def _generate_iam_statements(self, entry: BucketMapEntry) -> Generator[dict, None, None]:
-        assert entry._access_control, "Public buckets should be handled already"
-
-        for condition in self._generate_iam_conditions(entry._access_control):
-            statement = _IamStatement(
-                effect="Allow",
-                action=self.permissions,
-                resource=[
-                    f"arn:aws:s3:::{entry.bucket}",
-                    f"arn:aws:s3:::{entry.bucket}/*"
-                ],
-                condition=condition
-            )
-
-            yield statement.to_dict()
-
-    def _generate_iam_conditions(self, access_control: dict) -> Generator[dict, None, None]:
-        conditions = self._generate_string_match_conditions(access_control)
-
-        for string_like, string_not_like in conditions:
-            condition = {}
-            if string_like:
-                condition["StringLike"] = {
-                    "s3:prefix": string_like
-                }
-            if string_not_like:
-                condition["StringNotLike"] = {
-                    "s3:prefix": string_not_like
-                }
-
-            yield condition
-
-    def _generate_string_match_conditions(
-        self,
-        access_control: dict
-    ) -> Generator[Tuple[list, list], None, None]:
-        """Generate StringLike and StringNotLike lists needed to describe
-        bucket permissions in IAM policy terms.
-
-        Each pair of lists should be added as conditions on new allow
-        statement for the entire bucket.
+        Our consolidated access rules for a user in 'group' look like this:
+        {
+            "key1/": {"group", "group2"},
+            "key2/": {"group", "group2", "group3"},
+        }
         """
-        # Since we are limited to using prefix matching, we can only describe
-        # one nested interval per IAM statement.
-        #     public/private/public/
-        #     ^^^^^^^ allow
-        #     ^^^^^^^^^^^^^^^ deny
-        # Will allow anything in public/ but not public/private/. If we need to
-        # allow more stuff in public/private/public/ we'll need to use a second
-        # IAM statement for that.
+        if access_control is None:
+            return {"": None}
 
-        # Find all prefix intervals which we should be allowed to access
-        # Examples (allow, deny):
-        #    (public/, public/private/)
-        #    (public/private/public, public/private/public/private)
-        #    (, private/)
-        allowed_intervals = {}
+        consolidated = {}
         for key_prefix, access in reversed(access_control.items()):
             if self._is_accessible(access):
-                assert key_prefix not in allowed_intervals
-                allowed_intervals[key_prefix] = []
-                continue
+                longest_prefix = _get_longest_prefix(key_prefix, consolidated)
+                if longest_prefix is None:
+                    consolidated[key_prefix] = access
 
-            # NOTE: O(n**2) for n = len(access_control).
-            # Not a big deal unless someone has a seriously insane auto
-            # generated bucketmap that makes heavy use of prefix permissions
-            longest_prefix, _ = max(
-                ((k, len(k)) for k in allowed_intervals if key_prefix.startswith(k)),
-                key=lambda x: x[1],
-                default=(None, 0)
-            )
-            if longest_prefix is None:
-                continue
-
-            allowed_intervals[longest_prefix].append(key_prefix)
-
-        # Merge endpoints
-        # For example we may have a bunch of open intervals:
-        #     (public1/, )
-        #     (public2/, )
-        # Which should be merged into a single condition
-        allowed_intervals_endpoints = defaultdict(list)
-        for start_point, end_points in allowed_intervals.items():
-            allowed_intervals_endpoints[tuple(end_points)].append(start_point)
-
-        # Transform output so it makes more sense to humans
-        # Reversing list order is purely aesthetic so that the generated
-        # condition values are in the same order as in the bucket map.
-        yield from (
-            (
-                [s for s in like[::-1] if s],
-                [s for s in not_like[::-1] if s]
-            )
-            for not_like, like in allowed_intervals_endpoints.items()
-        )
+        return consolidated
 
 
 class _IamStatement:

--- a/tests/test_bucket_map.py
+++ b/tests/test_bucket_map.py
@@ -32,6 +32,32 @@ def sample_bucket_map():
 
 
 @pytest.fixture
+def sample_bucket_map_iam():
+    # A sample bucket map that is IAM compatible
+    return {
+        "MAP": {
+            "ANY_AUTHED": "authed-bucket",
+            "general-browse": "browse-bucket",
+            "productX": "bucket",
+            "nested": {
+                "nested2a": {
+                    "nested3": "nested-bucket-public"
+                },
+                "nested2b": "nested-bucket-private"
+            }
+        },
+        "PUBLIC_BUCKETS": {
+            "browse-bucket": "General browse Imagery",
+            "bucket/browse": "ProductX Browse Imagery"
+        },
+        "PRIVATE_BUCKETS": {
+            "bucket": ["science_team"],
+            "nested-bucket-private": []
+        }
+    }
+
+
+@pytest.fixture
 def groups_bucket_map():
     return {
         "PATH1": "bucket1",
@@ -538,12 +564,6 @@ def test_to_iam_policy_empty():
     assert b_map.to_iam_policy() is None
 
 
-def test_to_iam_policy_empty_permissions():
-    b_map = BucketMap({})
-
-    assert b_map.to_iam_policy(permissions=("s3:ListBucket",)) is None
-
-
 def test_to_iam_policy_simple():
     bucket_map = {
         "PATH": "bucket-name",
@@ -556,27 +576,6 @@ def test_to_iam_policy_simple():
             {
                 "Effect": "Allow",
                 "Action": ["s3:GetObject", "s3:ListBucket"],
-                "Resource": [
-                    "arn:aws:s3:::bucket-name",
-                    "arn:aws:s3:::bucket-name/*"
-                ]
-            }
-        ]
-    }
-
-
-def test_to_iam_policy_simple_permissions():
-    bucket_map = {
-        "PATH": "bucket-name",
-    }
-    b_map = BucketMap(bucket_map)
-
-    assert b_map.to_iam_policy(groups=(), permissions=("s3:ListBucket",)) == {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Action": ["s3:ListBucket"],
                 "Resource": [
                     "arn:aws:s3:::bucket-name",
                     "arn:aws:s3:::bucket-name/*"
@@ -643,14 +642,20 @@ def test_to_iam_policy_private_with_public_prefix():
         "Statement": [
             {
                 "Effect": "Allow",
-                "Action": ["s3:GetObject", "s3:ListBucket"],
+                "Action": ["s3:GetObject"],
+                "Resource": [
+                    "arn:aws:s3:::bucket-name/public/*"
+                ]
+            },
+            {
+                "Effect": "Allow",
+                "Action": ["s3:ListBucket"],
                 "Resource": [
                     "arn:aws:s3:::bucket-name",
-                    "arn:aws:s3:::bucket-name/*"
                 ],
                 "Condition": {
                     "StringLike": {
-                        "s3:prefix": ["public/"]
+                        "s3:prefix": ["public/*"]
                     }
                 }
             }
@@ -673,14 +678,22 @@ def test_to_iam_policy_private_with_protected_prefix():
         "Statement": [
             {
                 "Effect": "Allow",
-                "Action": ["s3:GetObject", "s3:ListBucket"],
+                "Action": ["s3:GetObject"],
+                "Resource": [
+                    "arn:aws:s3:::bucket-name/public/*"
+                ]
+            },
+            {
+                "Effect": "Allow",
+                "Action": ["s3:ListBucket"],
                 "Resource": [
                     "arn:aws:s3:::bucket-name",
-                    "arn:aws:s3:::bucket-name/*"
                 ],
                 "Condition": {
                     "StringLike": {
-                        "s3:prefix": ["public/"]
+                        "s3:prefix": [
+                            "public/*"
+                        ]
                     }
                 }
             }
@@ -688,18 +701,17 @@ def test_to_iam_policy_private_with_protected_prefix():
     }
 
 
-def test_to_iam_policy_private_with_protected_prefix_and_private_subprefix():
+def test_to_iam_policy_private_with_protected_prefix_full_access():
     bucket_map = {
         "PATH": "bucket-name",
         "PRIVATE_BUCKETS": {
             "bucket-name": ["science_team"],
-            "bucket-name/browse/": [],
-            "bucket-name/browse/secret/": ["science_team"]
+            "bucket-name/public/": []
         }
     }
     b_map = BucketMap(bucket_map)
 
-    assert b_map.to_iam_policy(groups=()) == {
+    assert b_map.to_iam_policy(groups=("science_team",)) == {
         "Version": "2012-10-17",
         "Statement": [
             {
@@ -708,181 +720,17 @@ def test_to_iam_policy_private_with_protected_prefix_and_private_subprefix():
                 "Resource": [
                     "arn:aws:s3:::bucket-name",
                     "arn:aws:s3:::bucket-name/*"
-                ],
-                "Condition": {
-                    "StringLike": {
-                        "s3:prefix": ["browse/"]
-                    },
-                    "StringNotLike": {
-                        "s3:prefix": ["browse/secret/"]
-                    }
-                }
+                ]
             }
         ]
     }
 
 
-def test_to_iam_policy_public_with_complex_nesting():
-    bucket_map = {
-        "PATH": "bucket-name",
-        "PUBLIC_BUCKETS": {
-            "bucket-name": "Public top level"
-        },
-        "PRIVATE_BUCKETS": {
-            "bucket-name/closed/": ["science_team"],
-            "bucket-name/closed/open/": [],
-            "bucket-name/closed/open/closed/": ["science_team"],
-            "bucket-name/closed/open/closed/open/": [],
-            "bucket-name/closed/open/closed/open/closed/": ["science_team"]
-        }
-    }
-    b_map = BucketMap(bucket_map)
-
-    assert b_map.to_iam_policy(groups=()) == {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Action": ["s3:GetObject", "s3:ListBucket"],
-                "Resource": [
-                    "arn:aws:s3:::bucket-name",
-                    "arn:aws:s3:::bucket-name/*"
-                ],
-                "Condition": {
-                    "StringNotLike": {
-                        "s3:prefix": [
-                            "closed/",
-                        ]
-                    }
-                }
-            },
-            {
-                "Effect": "Allow",
-                "Action": ["s3:GetObject", "s3:ListBucket"],
-                "Resource": [
-                    "arn:aws:s3:::bucket-name",
-                    "arn:aws:s3:::bucket-name/*"
-                ],
-                "Condition": {
-                    "StringLike": {
-                        "s3:prefix": [
-                            "closed/open/",
-                        ]
-                    },
-                    "StringNotLike": {
-                        "s3:prefix": [
-                            "closed/open/closed/",
-                        ]
-                    }
-                }
-            },
-            {
-                "Effect": "Allow",
-                "Action": ["s3:GetObject", "s3:ListBucket"],
-                "Resource": [
-                    "arn:aws:s3:::bucket-name",
-                    "arn:aws:s3:::bucket-name/*"
-                ],
-                "Condition": {
-                    "StringLike": {
-                        "s3:prefix": [
-                            "closed/open/closed/open/",
-                        ]
-                    },
-                    "StringNotLike": {
-                        "s3:prefix": [
-                            "closed/open/closed/open/closed/",
-                        ]
-                    }
-                }
-            }
-        ]
-    }
-
-
-def test_to_iam_policy_private_with_complex_nesting():
+def test_to_iam_policy_private_with_multiple_nested_private():
     bucket_map = {
         "PATH": "bucket-name",
         "PRIVATE_BUCKETS": {
-            "bucket-name/": ["science_team"],
-            "bucket-name/open/": [],
-            "bucket-name/open/closed/": ["science_team"],
-            "bucket-name/open/closed/open/": [],
-            "bucket-name/open/closed/open/closed/": ["science_team"],
-            "bucket-name/open/closed/open/closed/open/": []
-        }
-    }
-    b_map = BucketMap(bucket_map)
-
-    assert b_map.to_iam_policy(groups=()) == {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Action": ["s3:GetObject", "s3:ListBucket"],
-                "Resource": [
-                    "arn:aws:s3:::bucket-name",
-                    "arn:aws:s3:::bucket-name/*"
-                ],
-                "Condition": {
-                    "StringLike": {
-                        "s3:prefix": [
-                            "open/",
-                        ]
-                    },
-                    "StringNotLike": {
-                        "s3:prefix": [
-                            "open/closed/",
-                        ]
-                    }
-                }
-            },
-            {
-                "Effect": "Allow",
-                "Action": ["s3:GetObject", "s3:ListBucket"],
-                "Resource": [
-                    "arn:aws:s3:::bucket-name",
-                    "arn:aws:s3:::bucket-name/*"
-                ],
-                "Condition": {
-                    "StringLike": {
-                        "s3:prefix": [
-                            "open/closed/open/",
-                        ]
-                    },
-                    "StringNotLike": {
-                        "s3:prefix": [
-                            "open/closed/open/closed/",
-                        ]
-                    }
-                }
-            },
-            {
-                "Effect": "Allow",
-                "Action": ["s3:GetObject", "s3:ListBucket"],
-                "Resource": [
-                    "arn:aws:s3:::bucket-name",
-                    "arn:aws:s3:::bucket-name/*"
-                ],
-                "Condition": {
-                    "StringLike": {
-                        "s3:prefix": [
-                            "open/closed/open/closed/open/",
-                        ]
-                    }
-                }
-            }
-        ]
-    }
-
-
-def test_to_iam_policy_public_with_multiple_nested_private():
-    bucket_map = {
-        "PATH": "bucket-name",
-        "PUBLIC_BUCKETS": {
-            "bucket-name": "Public imagery"
-        },
-        "PRIVATE_BUCKETS": {
+            "bucket-name": ["science_team"],
             "bucket-name/closed1/": ["science_team"],
             "bucket-name/closed2/": ["science_team"],
             "bucket-name/closed3/": ["science_team"],
@@ -898,34 +746,25 @@ def test_to_iam_policy_public_with_multiple_nested_private():
         "Statement": [
             {
                 "Effect": "Allow",
-                "Action": ["s3:GetObject", "s3:ListBucket"],
+                "Action": ["s3:GetObject"],
                 "Resource": [
-                    "arn:aws:s3:::bucket-name",
-                    "arn:aws:s3:::bucket-name/*"
-                ],
-                "Condition": {
-                    "StringNotLike": {
-                        "s3:prefix": [
-                            "closed1/",
-                            "closed2/",
-                            "closed3/",
-                        ]
-                    }
-                }
+                    "arn:aws:s3:::bucket-name/closed1/open1/*",
+                    "arn:aws:s3:::bucket-name/closed1/open2/*",
+                    "arn:aws:s3:::bucket-name/closed1/open3/*",
+                ]
             },
             {
                 "Effect": "Allow",
-                "Action": ["s3:GetObject", "s3:ListBucket"],
+                "Action": ["s3:ListBucket"],
                 "Resource": [
                     "arn:aws:s3:::bucket-name",
-                    "arn:aws:s3:::bucket-name/*"
                 ],
                 "Condition": {
                     "StringLike": {
                         "s3:prefix": [
-                            "closed1/open1/",
-                            "closed1/open2/",
-                            "closed1/open3/",
+                            "closed1/open1/*",
+                            "closed1/open2/*",
+                            "closed1/open3/*"
                         ]
                     }
                 }
@@ -934,18 +773,17 @@ def test_to_iam_policy_public_with_multiple_nested_private():
     }
 
 
-def test_to_iam_policy_public_with_many_private_subprefixes():
+def test_to_iam_policy_private_with_multiple_nested_protected_multiple_buckets():
     bucket_map = {
-        "PATH": "bucket-name",
-        "PUBLIC_BUCKETS": {
-            "bucket-name": "Public top level"
-        },
+        "PATH1": "bucket1",
+        "PATH2": "bucket2",
         "PRIVATE_BUCKETS": {
-            "bucket-name/browse/": [],
-            "bucket-name/science/": ["science_team"],
-            "bucket-name/science2/": ["science_team_2"],
-            "bucket-name/science3/": ["science_team_3"],
-            "bucket-name/science4/": ["science_team_4"]
+            "bucket1": ["science_team"],
+            "bucket2": ["science_team"],
+            "bucket1/closed1/": ["science_team"],
+            "bucket2/closed2/": ["science_team"],
+            "bucket1/closed1/open1/": [],
+            "bucket2/closed1/open2/": [],
         }
     }
     b_map = BucketMap(bucket_map)
@@ -955,44 +793,89 @@ def test_to_iam_policy_public_with_many_private_subprefixes():
         "Statement": [
             {
                 "Effect": "Allow",
-                "Action": ["s3:GetObject", "s3:ListBucket"],
+                "Action": ["s3:GetObject"],
                 "Resource": [
-                    "arn:aws:s3:::bucket-name",
-                    "arn:aws:s3:::bucket-name/*"
-                ],
-                "Condition": {
-                    "StringNotLike": {
-                        "s3:prefix": [
-                            "science/",
-                            "science2/",
-                            "science3/",
-                            "science4/"
-                        ]
-                    }
-                }
+                    "arn:aws:s3:::bucket1/closed1/open1/*",
+                    "arn:aws:s3:::bucket2/closed1/open2/*",
+                ]
             },
-            # This statement is redundant, but makes the implementation simpler
             {
                 "Effect": "Allow",
-                "Action": ["s3:GetObject", "s3:ListBucket"],
+                "Action": ["s3:ListBucket"],
                 "Resource": [
-                    "arn:aws:s3:::bucket-name",
-                    "arn:aws:s3:::bucket-name/*"
+                    "arn:aws:s3:::bucket1",
                 ],
                 "Condition": {
                     "StringLike": {
                         "s3:prefix": [
-                            "browse/"
+                            "closed1/open1/*",
                         ]
                     }
                 }
             },
+            {
+                "Effect": "Allow",
+                "Action": ["s3:ListBucket"],
+                "Resource": [
+                    "arn:aws:s3:::bucket2",
+                ],
+                "Condition": {
+                    "StringLike": {
+                        "s3:prefix": [
+                            "closed1/open2/*",
+                        ]
+                    }
+                }
+            }
         ]
     }
 
 
-def test_to_iam_policy(sample_bucket_map):
-    b_map = BucketMap(sample_bucket_map, bucket_name_prefix="pre-")
+def test_to_iam_policy_merge_prefix_resources():
+    bucket_map = {
+        "PATH1": "bucket1",
+        "PATH2": "bucket2",
+        "PRIVATE_BUCKETS": {
+            "bucket1": ["science_team"],
+            "bucket2": ["science_team"],
+            "bucket1/theprefix/": [],
+            "bucket2/theprefix/": [],
+        }
+    }
+    b_map = BucketMap(bucket_map)
+
+    assert b_map.to_iam_policy(groups=()) == {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": ["s3:GetObject"],
+                "Resource": [
+                    "arn:aws:s3:::bucket1/theprefix/*",
+                    "arn:aws:s3:::bucket2/theprefix/*",
+                ]
+            },
+            {
+                "Effect": "Allow",
+                "Action": ["s3:ListBucket"],
+                "Resource": [
+                    "arn:aws:s3:::bucket1",
+                    "arn:aws:s3:::bucket2",
+                ],
+                "Condition": {
+                    "StringLike": {
+                        "s3:prefix": [
+                            "theprefix/*",
+                        ]
+                    }
+                }
+            }
+        ]
+    }
+
+
+def test_to_iam_policy(sample_bucket_map_iam):
+    b_map = BucketMap(sample_bucket_map_iam, bucket_name_prefix="pre-")
 
     assert b_map.to_iam_policy(groups=()) == {
         "Version": "2012-10-17",
@@ -1005,6 +888,7 @@ def test_to_iam_policy(sample_bucket_map):
                     "arn:aws:s3:::pre-authed-bucket/*",
                     "arn:aws:s3:::pre-browse-bucket",
                     "arn:aws:s3:::pre-browse-bucket/*",
+                    "arn:aws:s3:::pre-bucket/browse*",
                     "arn:aws:s3:::pre-nested-bucket-public",
                     "arn:aws:s3:::pre-nested-bucket-public/*",
                     "arn:aws:s3:::pre-nested-bucket-private",
@@ -1013,28 +897,15 @@ def test_to_iam_policy(sample_bucket_map):
             },
             {
                 "Effect": "Allow",
-                "Action": ["s3:GetObject", "s3:ListBucket"],
+                "Action": ["s3:ListBucket"],
                 "Resource": [
                     "arn:aws:s3:::pre-bucket",
-                    "arn:aws:s3:::pre-bucket/*"
-                ],
-                "Condition": {
-                    "StringNotLike": {
-                        "s3:prefix": ["2020/12"]
-                    }
-                }
-            },
-            # This statement is redundant, but makes the implementation simpler
-            {
-                "Effect": "Allow",
-                "Action": ["s3:GetObject", "s3:ListBucket"],
-                "Resource": [
-                    "arn:aws:s3:::pre-bucket",
-                    "arn:aws:s3:::pre-bucket/*"
                 ],
                 "Condition": {
                     "StringLike": {
-                        "s3:prefix": ["browse"]
+                        "s3:prefix": [
+                            "browse*",
+                        ]
                     }
                 }
             }


### PR DESCRIPTION
Adds an IAM compatibility mode (on by default) to restrict the type of access rule configurations that are allowed in a bucket map so that it's actually possible to generate an IAM policy that adheres to the same rules. The rule for IAM compatibility mode is:

- Access for parent prefixes must always be a subset of access for child prefixes

Intuitively this means if you have some prefixes that are extensions of other prefixes, (such as `/foo/` and `/foo/bar/`), the nested prefixes must always be at least as open or more open than their parents. So if `/foo/` is public then `/foo/bar/` must also be public. If `/foo/` is restricted to only the `science_team` group, then `/foo/bar/` can have any permission configuration as long as `science_team` is included.

This guarantees that we can always generate a correct policy using trailing `*` wildcards, and it should still be sufficient for making prefixes be useful. This does break one of the examples on our tea-docs page however, so that will need to be explained when this is merged to TEA.

I also added a little `tkinter` GUI app where you can interactively write a bucket map and see what IAM policy will be generated. This could be useful for testing and coming up with unit test cases.