### PR TITLE
PR-4752 Fix issue with presigned URLs not working for keys with weird characters

### DIFF
--- a/rain_api_core/egress_util.py
+++ b/rain_api_core/egress_util.py
@@ -20,34 +20,33 @@ def get_bucket_name_prefix() -> str:
 
 
 def hmacsha256(key: bytes, string: str) -> hmac.HMAC:
-    return hmac.new(key, string.encode('utf-8'), sha256)
+    return hmac.new(key, string.encode(), sha256)
 
 
 def get_presigned_url(session, bucket_name, object_name, region_name, expire_seconds, user_id, method='GET') -> str:
     timez = datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
     datez = timez[:8]
-    hostname = "{0}.s3{1}.amazonaws.com".format(bucket_name, "." + region_name if region_name != "us-east-1" else "")
+    region_id = "." + region_name if region_name != "us-east-1" else ""
+    hostname = f"{bucket_name}.s3{region_id}.amazonaws.com"
 
     cred = session['Credentials']['AccessKeyId']
     secret = session['Credentials']['SecretAccessKey']
     token = session['Credentials']['SessionToken']
 
     aws4_request = "/".join([datez, region_name, "s3", "aws4_request"])
-    cred_string = "{0}/{1}".format(cred, aws4_request)
+    cred_string = f"{cred}/{aws4_request}"
 
-    # Canonical Query String Parts
-    parts = ["A-userid={0}".format(user_id),
-             "X-Amz-Algorithm=AWS4-HMAC-SHA256",
-             "X-Amz-Credential="+urllib.parse.quote_plus(cred_string),
-             "X-Amz-Date="+timez,
-             "X-Amz-Expires={0}".format(expire_seconds),
-             "X-Amz-Security-Token="+urllib.parse.quote_plus(token),
-             "X-Amz-SignedHeaders=host"]
+    can_query_string = "&".join([
+        f"A-userid={user_id}",
+        "X-Amz-Algorithm=AWS4-HMAC-SHA256",
+        "X-Amz-Credential=" + urllib.parse.quote_plus(cred_string),
+        "X-Amz-Date=" + timez,
+        f"X-Amz-Expires={expire_seconds}",
+        "X-Amz-Security-Token=" + urllib.parse.quote_plus(token),
+        "X-Amz-SignedHeaders=host"
+    ])
 
-    can_query_string = "&".join(parts)
-
-    # Canonical Requst
-    can_req = (
+    can_request = (
         f"{method}\n"
         f"/{object_name}\n"
         f"{can_query_string}\n"
@@ -55,20 +54,20 @@ def get_presigned_url(session, bucket_name, object_name, region_name, expire_sec
         "host\n"
         "UNSIGNED-PAYLOAD"
     )
-    can_req_hash = sha256(can_req.encode('utf-8')).hexdigest()
+    can_request_hash = sha256(can_request.encode()).hexdigest()
 
-    # String to Sign
-    stringtosign = "\n".join(["AWS4-HMAC-SHA256", timez, aws4_request, can_req_hash])
+    string_to_sign = "\n".join([
+        "AWS4-HMAC-SHA256",
+        timez,
+        aws4_request,
+        can_request_hash
+    ])
 
-    # Signing Key
-    StepOne = hmacsha256("AWS4{0}".format(secret).encode('utf-8'), datez).digest()
-    StepTwo = hmacsha256(StepOne, region_name).digest()
-    StepThree = hmacsha256(StepTwo, "s3").digest()
-    SigningKey = hmacsha256(StepThree, "aws4_request").digest()
+    step_one = hmacsha256(f"AWS4{secret}".encode(), datez).digest()
+    step_two = hmacsha256(step_one, region_name).digest()
+    step_three = hmacsha256(step_two, "s3").digest()
+    signing_key = hmacsha256(step_three, "aws4_request").digest()
 
-    # Final Signature
-    Signature = hmacsha256(SigningKey, stringtosign).hexdigest()
+    signature = hmacsha256(signing_key, string_to_sign).hexdigest()
 
-    # Dump URL
-    url = "https://" + hostname + "/" + object_name + "?" + can_query_string + "&X-Amz-Signature=" + Signature
-    return url
+    return f"https://{hostname}/{object_name}?{can_query_string}&X-Amz-Signature={signature}"

--- a/rain_api_core/egress_util.py
+++ b/rain_api_core/egress_util.py
@@ -28,6 +28,7 @@ def get_presigned_url(session, bucket_name, object_name, region_name, expire_sec
     datez = timez[:8]
     region_id = "." + region_name if region_name != "us-east-1" else ""
     hostname = f"{bucket_name}.s3{region_id}.amazonaws.com"
+    object_name = urllib.parse.quote(object_name)
 
     cred = session['Credentials']['AccessKeyId']
     secret = session['Credentials']['SecretAccessKey']

--- a/tests/test_egress_util.py
+++ b/tests/test_egress_util.py
@@ -44,3 +44,75 @@ def test_get_presigned_url(mock_datetime):
         "&X-Amz-SignedHeaders=host"
         "&X-Amz-Signature=766aa9d15ec05d33bb6de720b02e8b9cf7d96def24a94cba3e0b39f19b302834"
     )
+
+
+@mock.patch(f"{MODULE}.datetime", autospec=True)
+def test_get_presigned_url_with_spaces(mock_datetime):
+    mock_datetime.utcnow.return_value = datetime(2015, 1, 1)
+    session = {
+        "Credentials": {
+            "AccessKeyId": "access_key_id",
+            "SecretAccessKey": "secret_access_key",
+            "SessionToken": "session_token"
+        }
+    }
+    presigned_url = get_presigned_url(session, "bucket_name", "has spaces ", "region_name", 1000, "user_id")
+    assert presigned_url == (
+        "https://bucket_name.s3.region_name.amazonaws.com/has%20spaces%20"
+        "?A-userid=user_id"
+        "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
+        "&X-Amz-Credential=access_key_id%2F20150101%2Fregion_name%2Fs3%2Faws4_request"
+        "&X-Amz-Date=20150101T000000Z"
+        "&X-Amz-Expires=1000"
+        "&X-Amz-Security-Token=session_token"
+        "&X-Amz-SignedHeaders=host"
+        "&X-Amz-Signature=99787202e2729ab15cea657f8a1a78716e570fc65a07c5fb60128ab205753ace"
+    )
+
+
+@mock.patch(f"{MODULE}.datetime", autospec=True)
+def test_get_presigned_url_with_colons(mock_datetime):
+    mock_datetime.utcnow.return_value = datetime(2015, 1, 1)
+    session = {
+        "Credentials": {
+            "AccessKeyId": "access_key_id",
+            "SecretAccessKey": "secret_access_key",
+            "SessionToken": "session_token"
+        }
+    }
+    presigned_url = get_presigned_url(session, "bucket_name", "has_:colons:", "region_name", 1000, "user_id")
+    assert presigned_url == (
+        "https://bucket_name.s3.region_name.amazonaws.com/has_%3Acolons%3A"
+        "?A-userid=user_id"
+        "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
+        "&X-Amz-Credential=access_key_id%2F20150101%2Fregion_name%2Fs3%2Faws4_request"
+        "&X-Amz-Date=20150101T000000Z"
+        "&X-Amz-Expires=1000"
+        "&X-Amz-Security-Token=session_token"
+        "&X-Amz-SignedHeaders=host"
+        "&X-Amz-Signature=f664672404aa1f98d2017c386011b3cb20625ca21cf082420c67b4bca3891489"
+    )
+
+
+@mock.patch(f"{MODULE}.datetime", autospec=True)
+def test_get_presigned_url_with_newlines(mock_datetime):
+    mock_datetime.utcnow.return_value = datetime(2015, 1, 1)
+    session = {
+        "Credentials": {
+            "AccessKeyId": "access_key_id",
+            "SecretAccessKey": "secret_access_key",
+            "SessionToken": "session_token"
+        }
+    }
+    presigned_url = get_presigned_url(session, "bucket_name", "has\nnewlines\n", "region_name", 1000, "user_id")
+    assert presigned_url == (
+        "https://bucket_name.s3.region_name.amazonaws.com/has%0Anewlines%0A"
+        "?A-userid=user_id"
+        "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
+        "&X-Amz-Credential=access_key_id%2F20150101%2Fregion_name%2Fs3%2Faws4_request"
+        "&X-Amz-Date=20150101T000000Z"
+        "&X-Amz-Expires=1000"
+        "&X-Amz-Security-Token=session_token"
+        "&X-Amz-SignedHeaders=host"
+        "&X-Amz-Signature=b5f7dab0ba1af2a1a5c625f526de6ab8047a20f165675890cfa8caf70cfed730"
+    )


### PR DESCRIPTION
Through empirical analysis I have determined that URL encoding the object name before generating the signature results in valid presigned URLs that work even when there are colons, spaces and newlines in the object key.