### PR TITLE
Ensure prefixes are evaluated in the correct order

### DIFF
--- a/rain_api_core/bucket_map.py
+++ b/rain_api_core/bucket_map.py
@@ -216,7 +216,7 @@ def _parse_access_control(bucket_map: dict) -> dict:
 
     # Relying on the fact that `sort` is stable. The order in which we add
     # public/private rules to `access_list` is therefore important.
-    access_list.sort(key=lambda item: item[0].count("/"), reverse=True)
+    access_list.sort(key=lambda item: len(item[0]), reverse=True)
 
     # Convert to dictionary for easier lookup on individual buckets
     # We're relying on python's dictionary keys being insertion ordered

--- a/tests/test_bucket_map.py
+++ b/tests/test_bucket_map.py
@@ -397,6 +397,70 @@ def test_check_bucket_access_conflicting():
     assert b_map.get("PATH/obj1").is_accessible(groups=["some_permission"]) is True
 
 
+def test_check_bucket_access_longest_prefix_first():
+    # Longer prefixes should be checked first
+    bucket_map = {
+        "MAP": {
+            "PATH": "bucket"
+        },
+        "PUBLIC_BUCKETS": [
+            "bucket"
+        ],
+        "PRIVATE_BUCKETS": {
+            "bucket/foobar": ["other_permission"],
+            "bucket/foo": ["some_permission"],
+        }
+    }
+    b_map = BucketMap(bucket_map, iam_compatible=False)
+
+    assert b_map.get("PATH/foobar").is_accessible() is False
+    assert b_map.get("PATH/foobar").is_accessible(groups=["some_permission"]) is False
+    assert b_map.get("PATH/foobar").is_accessible(groups=["other_permission"]) is True
+
+
+def test_check_bucket_access_longest_prefix_first_order():
+    # Longer prefixes should be checked first
+    bucket_map = {
+        "MAP": {
+            "PATH": "bucket"
+        },
+        "PUBLIC_BUCKETS": [
+            "bucket"
+        ],
+        "PRIVATE_BUCKETS": {
+            "bucket/foo": ["some_permission"],
+            "bucket/foobar": ["other_permission"],
+        }
+    }
+    b_map = BucketMap(bucket_map, iam_compatible=False)
+
+    assert b_map.get("PATH/foobar").is_accessible() is False
+    assert b_map.get("PATH/foobar").is_accessible(groups=["some_permission"]) is False
+    assert b_map.get("PATH/foobar").is_accessible(groups=["other_permission"]) is True
+
+
+def test_check_bucket_access_longest_prefix_first_conflicting():
+    # Longer prefixes should be checked first
+    bucket_map = {
+        "MAP": {
+            "PATH": "bucket"
+        },
+        "PUBLIC_BUCKETS": [
+            "bucket/foo",
+            "bucket/foobar"
+        ],
+        "PRIVATE_BUCKETS": {
+            "bucket/foo": ["some_permission"],
+            "bucket/foobar": ["other_permission"],
+        }
+    }
+    b_map = BucketMap(bucket_map, iam_compatible=False)
+
+    assert b_map.get("PATH/foobar").is_accessible() is False
+    assert b_map.get("PATH/foobar").is_accessible(groups=["some_permission"]) is False
+    assert b_map.get("PATH/foobar").is_accessible(groups=["other_permission"]) is True
+
+
 def test_check_bucket_access_nested_paths():
     bucket_map = {
         "MAP": {


### PR DESCRIPTION
Fixes a bug where a prefix could be evaluated using the wrong permissions if it had the same number of `/`s as another prefix.