### PR TITLE
Allow floats to be passed to session_ttl_in_hours parameter

### DIFF
--- a/rain_api_core/auth.py
+++ b/rain_api_core/auth.py
@@ -56,13 +56,13 @@ class JwtManager:
         private_key: str,
         cookie_name: str,
         blacklist={},
-        session_ttl_in_hours: int = 7 * 24
+        session_ttl_in_hours: float = 7 * 24
     ):
         self.algorithm = algorithm
         self.public_key = public_key
         self.private_key = private_key
         self.cookie_name = cookie_name
-        self.session_ttl = session_ttl_in_hours * 60 * 60
+        self.session_ttl = int(session_ttl_in_hours * 60 * 60)
         self.black_list = blacklist
 
     def _get_auth_cookie(self, headers: Mapping[str, str]):

--- a/rain_api_core/aws_util.py
+++ b/rain_api_core/aws_util.py
@@ -72,7 +72,7 @@ def retrieve_secret(secret_name: str) -> dict:
             duration=duration(timer)
         ))
     except ClientError as e:
-        log.error("Encountered fatal error trying to reading URS Secret: {0}".format(e))
+        log.error("Encountered fatal error trying to read URS Secret: {0}".format(e))
         raise e
     else:
         # Decrypts secret using the associated KMS CMK.

--- a/rain_api_core/aws_util.py
+++ b/rain_api_core/aws_util.py
@@ -214,9 +214,10 @@ def get_role_session(creds: dict = None, user_id: str = None) -> boto_Session:
     if session_id not in session_cache:
         now = time()
         session_cache[session_id] = boto_Session(
-                                        aws_access_key_id=sts_resp['Credentials']['AccessKeyId'],
-                                        aws_secret_access_key=sts_resp['Credentials']['SecretAccessKey'],
-                                        aws_session_token=sts_resp['Credentials']['SessionToken'])
+            aws_access_key_id=sts_resp['Credentials']['AccessKeyId'],
+            aws_secret_access_key=sts_resp['Credentials']['SecretAccessKey'],
+            aws_session_token=sts_resp['Credentials']['SessionToken']
+        )
         log.info(return_timing_object(service="boto3", endpoint="boto3.session()", duration=duration(now)))
     else:
         log.info("Reusing session {0}".format(session_id))

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -31,7 +31,7 @@ def test_decode_jwt_expired(jwt_manager, jwt_priv_key):
     assert jwt_manager._decode_jwt(encoded) is None
 
 
-def test_decode_jwt_invalid(jwt_manager, jwt_priv_key):
+def test_decode_jwt_invalid(jwt_manager):
     encoded = b".".join((
         jwt.utils.base64url_encode(b'{"alg": "RS256"}'),
         jwt.utils.base64url_encode(b'{"not valid'),
@@ -144,7 +144,6 @@ def test_get_header_to_set_auth_cookie(
     mock_time,
     mock_encode_jwt,
     jwt_manager,
-    jwt_priv_key,
 ):
     jwt_manager.cookie_name = 'auth-cookie'
     jwt_manager.session_ttl = 1

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -175,3 +175,35 @@ def test_get_header_to_set_auth_cookie(
 def test_get_header_to_set_auth_cookie_logout(jwt_manager):
     header = jwt_manager.get_header_to_set_auth_cookie(None, 'DOMAIN')
     assert header == {'SET-COOKIE': 'auth-cookie=expired; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Domain=DOMAIN'}
+
+
+@mock.patch(f'{MODULE}.time', autospec=True)
+def test_jwt_manager_session_ttl_sub_hour(mock_time):
+    jwt_manager = JwtManager(
+        "RSA256",
+        "",
+        "private_key",
+        "cookie_name",
+        session_ttl_in_hours=0.5
+    )
+    profile = UserProfile(
+        user_id='test_user_id',
+        token='test_token',
+        groups=['test_group1', 'test_group2'],
+        first_name='test_first_name',
+        last_name='test_last_name',
+        email='test_email',
+    )
+    mock_time.return_value = 1
+
+    payload = jwt_manager._jwt_payload_from_user_profile(profile)
+    assert payload == {
+        'urs-user-id': 'test_user_id',
+        'first_name': 'test_first_name',
+        'last_name': 'test_last_name',
+        'email': 'test_email',
+        'urs-access-token': 'test_token',
+        'urs-groups': ['test_group1', 'test_group2'],
+        'iat': 1,
+        'exp': 1801,
+    }


### PR DESCRIPTION
The `exp` field allows integer granularity in seconds, so we need to be able to allow for that with the hours parameter. It would probably be strange for anyone to be setting the TTL to sub-hour values but not impossible and it is useful for testing.