### PR TITLE
PR-3242 Refactor EDL calls

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - run: pip install -r requirements.txt
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install dependencies
       run: |

--- a/rain_api_core/edl.py
+++ b/rain_api_core/edl.py
@@ -1,0 +1,130 @@
+import json
+import logging
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Optional
+
+from rain_api_core.general_util import return_timing_object
+from rain_api_core.timer import Timer
+
+log = logging.getLogger(__name__)
+
+
+class EdlException(Exception):
+    def __init__(
+        self,
+        inner: Exception,
+        msg: dict,
+        payload: Optional[bytes],
+    ):
+        self.inner = inner
+        self.msg = msg
+        self.payload = payload
+
+
+class EulaException(EdlException):
+    pass
+
+
+class EdlClient:
+    def __init__(
+        self,
+        base_url: str = os.getenv(
+            'AUTH_BASE_URL',
+            'https://urs.earthdata.nasa.gov',
+        ),
+    ):
+        self.base_url = base_url
+
+    def request(
+        self,
+        method: str,
+        endpoint: str,
+        params: dict = {},
+        data: dict = {},
+        headers: dict = {},
+    ) -> dict:
+        if params:
+            params_encoded = urllib.parse.urlencode(params)
+            url_params = f'?{params_encoded}'
+        else:
+            url_params = ''
+
+        # Separate variables so we can log the url without params
+        url = urllib.parse.urljoin(self.base_url, endpoint)
+        url_with_params = url + url_params
+
+        if data:
+            data_encoded = urllib.parse.urlencode(data).encode()
+        else:
+            data_encoded = None
+
+        request = urllib.request.Request(
+            url=url_with_params,
+            data=data_encoded,
+            headers=headers,
+            method=method,
+        )
+
+        log.debug(
+            'Request(url=%r, data=%r, headers=%r)',
+            url_with_params,
+            data,
+            headers,
+        )
+
+        timer = Timer()
+        timer.mark(f'urlopen({url})')
+        try:
+            with urllib.request.urlopen(request) as f:
+                payload = f.read()
+                timer.mark('json.loads()')
+                msg = json.loads(payload)
+            timer.mark()
+
+            log.info(
+                return_timing_object(
+                    service='EDL',
+                    endpoint=url,
+                    duration=timer.total.duration() * 1000,
+                    unit='milliseconds',
+                ),
+            )
+            timer.log_all(log)
+
+            return msg
+        except urllib.error.URLError as e:
+            log.error('Error hitting endpoint %s: %s', url, e)
+            timer.mark()
+            log.debug('ET for the attempt: %.4f', timer.total.duration())
+
+            self._parse_edl_error(e)
+        except json.JSONDecodeError as e:
+            raise EdlException(e, {}, payload)
+
+    def _parse_edl_error(self, e: urllib.error.URLError):
+        if isinstance(e, urllib.error.HTTPError):
+            payload = e.read()
+            try:
+                msg = json.loads(payload)
+            except json.JSONDecodeError:
+                log.error('Could not get json message from payload: %s', payload)
+                msg = {}
+
+            if (
+                e.code in (403, 401)
+                and 'error_description' in msg
+                and 'eula' in msg['error_description'].lower()
+            ):
+                # sample json in this case:
+                # `{"status_code": 403, "error_description": "EULA Acceptance Failure",
+                #   "resolution_url": "http://uat.urs.earthdata.nasa.gov/approve_app?client_id=LqWhtVpLmwaD4VqHeoN7ww"}`
+                log.warning('user needs to sign the EULA')
+                raise EulaException(e, msg, payload)
+        else:
+            payload = None
+            msg = {}
+
+        raise EdlException(e, msg, payload)

--- a/tests/test_edl.py
+++ b/tests/test_edl.py
@@ -1,0 +1,107 @@
+import io
+import json
+import urllib.error
+from unittest import mock
+
+import pytest
+
+from rain_api_core.edl import EdlClient, EdlException, EulaException
+
+MODULE = "rain_api_core.edl"
+
+
+@pytest.fixture
+def edl_client():
+    return EdlClient()
+
+
+@mock.patch(f"{MODULE}.urllib.request.urlopen", autospec=True)
+def test_client_request(mock_urlopen, edl_client):
+    mock_urlopen(mock.ANY).__enter__().read.return_value = b'{"foo": "bar"}'
+
+    response = edl_client.request(
+        "POST",
+        "/foo/bar",
+        params={
+            "param_1": "value_1",
+            "param_2": "value_2",
+        },
+        data={
+            "data_1": "value_1",
+            "data_2": "value_2",
+        },
+        headers={"header_1": "value_1"},
+    )
+
+    request_obj = mock_urlopen.mock_calls[2].args[0]
+
+    assert response == {"foo": "bar"}
+    assert request_obj.method == "POST"
+    assert request_obj.full_url == (
+        "https://urs.earthdata.nasa.gov/foo/bar?param_1=value_1&param_2=value_2"
+    )
+    assert request_obj.data == b"data_1=value_1&data_2=value_2"
+    assert request_obj.headers == {"Header_1": "value_1"}
+
+
+@mock.patch(f"{MODULE}.urllib.request.urlopen", autospec=True)
+def test_client_request_urlerror(mock_urlopen, edl_client):
+    test_error = urllib.error.URLError("test error")
+    mock_urlopen.side_effect = test_error
+
+    with pytest.raises(EdlException) as ex_info:
+        edl_client.request("GET", "/foo/bar")
+
+    assert ex_info.value.inner is test_error
+    assert ex_info.value.msg == {}
+    assert ex_info.value.payload is None
+
+
+@mock.patch(f"{MODULE}.urllib.request.urlopen", autospec=True)
+def test_client_request_httperror(mock_urlopen, edl_client):
+    test_error = urllib.error.HTTPError(
+        url="/foo/bar",
+        code=500,
+        msg="Internal Server Error",
+        hdrs={},
+        fp=io.BytesIO(b'{"foo": "bar"}'),
+    )
+    mock_urlopen.side_effect = test_error
+
+    with pytest.raises(EdlException) as ex_info:
+        edl_client.request("GET", "/foo/bar")
+
+    assert ex_info.value.inner is test_error
+    assert ex_info.value.msg == {"foo": "bar"}
+    assert ex_info.value.payload == b'{"foo": "bar"}'
+
+
+@mock.patch(f"{MODULE}.urllib.request.urlopen", autospec=True)
+def test_client_request_httperror_eula(mock_urlopen, edl_client):
+    error_response = {
+        "error": "invalid_token",
+        "status_code": 401,
+        "error_description": "EULA Acceptance Failure",
+        "resolution_url": "https://uat.urs.earthdata.nasa.gov/approve_app",
+    }
+    error_response_encoded = json.dumps(error_response).encode()
+    test_error = urllib.error.HTTPError(
+        url="/foo/bar",
+        code=401,
+        msg="Unauthorized",
+        hdrs={},
+        fp=io.BytesIO(error_response_encoded),
+    )
+    mock_urlopen.side_effect = test_error
+
+    with pytest.raises(EulaException) as ex_info:
+        edl_client.request("GET", "/foo/bar")
+
+    assert ex_info.value.inner is test_error
+    assert ex_info.value.msg == {
+        "error": "invalid_token",
+        "status_code": 401,
+        "error_description": "EULA Acceptance Failure",
+        "resolution_url": "https://uat.urs.earthdata.nasa.gov/approve_app",
+    }
+    assert ex_info.value.payload == error_response_encoded


### PR DESCRIPTION
Refactor urllib request calls to EDL to an EDL client so that each request is handled consistently with regards to the timing code, log calls and error handling.

I tested this by deploying a dev stack of TEA and running a few checks with bearer tokens and browser downloads. https://github.com/asfadmin/thin-egress-app/pull/855