### PR TITLE
PR-3242 Add client_id to query params in get_profile

### DIFF
--- a/rain_api_core/urs_util.py
+++ b/rain_api_core/urs_util.py
@@ -109,12 +109,14 @@ def get_profile(
 
     headers = {'Authorization': 'Bearer ' + headertoken}
     headers.update(aux_headers)
+    params = {'client_id': get_urs_creds()['UrsId']}
 
     client = EdlClient()
     try:
         user_profile = client.request(
             'GET',
             f'/api/users/{user_id}',
+            params=params,
             headers=headers,
         )
         return get_user_profile(user_profile, headertoken)

--- a/tests/test_urs_util.py
+++ b/tests/test_urs_util.py
@@ -125,7 +125,9 @@ def test_get_urs_url(mock_get_urs_creds, context):
 
 
 @mock.patch(f"{MODULE}.EdlClient", autospec=True)
-def test_get_profile(mock_client):
+@mock.patch(f"{MODULE}.get_urs_creds", autospec=True)
+def test_get_profile(mock_get_urs_creds, mock_client):
+    mock_get_urs_creds.return_value = {"UrsId": "URS_ID"}
     mock_client().request.return_value = {
         "uid": "user_id",
         "first_name": "John",
@@ -140,13 +142,20 @@ def test_get_profile(mock_client):
 
     profile = get_profile("user_id", "token", "temptoken")
     assert profile.user_id == "user_id"
+
     assert get_profile(None, "token") is None
     assert get_profile("user_id", None) is None
 
 
 @mock.patch(f"{MODULE}.EdlClient", autospec=True)
 @mock.patch(f"{MODULE}.get_new_token_and_profile", autospec=True)
-def test_get_profile_error(mock_get_new_token_and_profile, mock_client):
+@mock.patch(f"{MODULE}.get_urs_creds", autospec=True)
+def test_get_profile_error(
+    mock_get_urs_creds,
+    mock_get_new_token_and_profile,
+    mock_client,
+):
+    mock_get_urs_creds.return_value = {"UrsId": "URS_ID"}
     mock_get_new_token_and_profile.return_value = {"foo": "bar"}
     mock_client().request.side_effect = EdlException(
         urllib.error.URLError("test error"),


### PR DESCRIPTION
We can shortcut the user profile fetching by using the provided bearer token with the `/api/users/<user_id>` end point directly. However, this requires us to provide the `client_id` as a query parameter.