### PR TITLE
PR-6290 Update CI branch name to 'main'

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,7 @@ jobs:
         with:
           python-version: 3.9
 
-      - run: pip install -r requirements.txt
-
       - uses: TrueBrain/actions-flake8@v2
         with:
-          plugins: flake8-isort
+          flake8_version: 6.0.0
+          plugins: flake8-isort==6.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - devel
-      - master
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
Flake8 was failing because the flake8 version wasn't pinned